### PR TITLE
Add wms

### DIFF
--- a/api/endpoints/wms.py
+++ b/api/endpoints/wms.py
@@ -22,6 +22,7 @@ class GetMap(Resource):
         :return:
         """
         try:
+            print(json.dumps(request.args, indent=2))
             wmts_getcapabilities_filename = 'maap.wmts.xml'
 
             # TODO(Aimee): This avoids an error response from CMR "Parameter [service]
@@ -41,10 +42,10 @@ class GetMap(Resource):
             wmts_confs = create_config_wmts(["file://" + os.path.abspath(wmts_getcapabilities_filename)])
 
             # Get args from request
-            bbox = (11.41071054972465, -0.3848431107778577, 11.857202093935395, 0.09666737807686826)
-            size = (1200, 600)
-            layer = 'AfriSAR_UAVSAR_Coreg_SLC'
-            img_format = 'image/png'
+            bbox = tuple(map(float, request.args['BBOX'].split(',')))
+            size = (int(request.args['HEIGHT']), int(request.args['WIDTH']))
+            layer = request.args['LAYERS'][0]
+            img_format = request.args['FORMAT']
             img_data = mapit(wmts_confs, layer, img_format, bbox, size)
 
             response = Response(

--- a/api/endpoints/wms.py
+++ b/api/endpoints/wms.py
@@ -1,0 +1,58 @@
+import logging
+import json
+import os
+import sys, traceback
+import requests
+from flask import Response, request, render_template_string
+from flask_restplus import Resource
+from api.restplus import api
+from api.utils.mapproxy_snap import create_config_wmts, mapit
+from api.endpoints.wmts import GetCapabilities
+
+log = logging.getLogger(__name__)
+
+ns = api.namespace('wms', description='WMS GetMap')
+
+@ns.route('/GetMap')
+class GetMap(Resource):
+
+    def get(self):
+        """
+        This will return OGC WMS GetMap response (image file)
+        :return:
+        """
+        try:
+            wmts_getcapabilities_filename = 'maap.wmts.xml'
+            print('request.args')
+            print(json.dumps(request.args, indent=2))
+            get_capabilities_string = GetCapabilities().generate_capabilities(request.args)
+            wmts_capabilities_file = open(wmts_getcapabilities_filename, 'w')
+            wmts_capabilities_file.write(get_capabilities_string)
+            wmts_capabilities_file.close()
+
+            wmts_confs = create_config_wmts(["file://" + os.path.abspath(wmts_getcapabilities_filename)])
+
+            # Get args from request
+            bbox = (11.41071054972465, -0.3848431107778577, 11.857202093935395, 0.09666737807686826)
+            size = (1200, 600)
+            layer = 'AfriSAR_UAVSAR_Coreg_SLC'
+            img_format = 'image/png'
+            img_data = mapit(wmts_confs, layer, img_format, bbox, size)
+
+            response = Response(
+                img_data,
+                200,
+                {
+                    'Content-Type': img_format,
+                    'Access-Control-Allow-Origin': '*'
+                })
+            return response
+        except Exception as ex:
+            response_body = dict()
+            log.error(str(ex))
+            log.error(json.dumps(ex, indent=2))
+            response_body["code"] = 500
+            response_body["message"] = 'Failed to generate map'
+            response_body["error"] = str(ex)
+            response_body["success"] = False
+            return response_body

--- a/api/endpoints/wms.py
+++ b/api/endpoints/wms.py
@@ -23,9 +23,17 @@ class GetMap(Resource):
         """
         try:
             wmts_getcapabilities_filename = 'maap.wmts.xml'
-            print('request.args')
-            print(json.dumps(request.args, indent=2))
-            get_capabilities_string = GetCapabilities().generate_capabilities(request.args)
+
+            # TODO(Aimee): This avoids an error response from CMR "Parameter [service]
+            # was not recognized" but we probably want a longer list of permitted
+            # params.
+            cmr_search_params_whitelist = ['granule_ur', 'short_name', 'version']
+            cmr_search_params = {}
+            for key in cmr_search_params_whitelist:
+                if key in request.args:
+                   cmr_search_params[key] = request.args[key]
+
+            get_capabilities_string = GetCapabilities().generate_capabilities(cmr_search_params)
             wmts_capabilities_file = open(wmts_getcapabilities_filename, 'w')
             wmts_capabilities_file.write(get_capabilities_string)
             wmts_capabilities_file.close()

--- a/api/endpoints/wmts.py
+++ b/api/endpoints/wmts.py
@@ -48,6 +48,7 @@ def get_cog_urls_string(params={}):
     search_headers = cmr.get_search_headers()
     search_headers['Accept'] = 'application/json'
     cmr_resp = requests.get(cmr_search_granules_url, headers=search_headers, params=params)
+
     cmr_response_feed = json.loads(cmr_resp.text)['feed']['entry']
     for granule in cmr_response_feed:
         granule = Granule(granule, 'aws_access_key_id', 'aws_secret_access_key')

--- a/api/endpoints/wmts.py
+++ b/api/endpoints/wmts.py
@@ -48,7 +48,6 @@ def get_cog_urls_string(params={}):
     search_headers = cmr.get_search_headers()
     search_headers['Accept'] = 'application/json'
     cmr_resp = requests.get(cmr_search_granules_url, headers=search_headers, params=params)
-
     cmr_response_feed = json.loads(cmr_resp.text)['feed']['entry']
     for granule in cmr_response_feed:
         granule = Granule(granule, 'aws_access_key_id', 'aws_secret_access_key')

--- a/api/maapapp.py
+++ b/api/maapapp.py
@@ -10,6 +10,7 @@ from api.endpoints.cmr import ns as cmr_collections_namespace
 from api.endpoints.algorithm import ns as algorithm_namespace
 from api.endpoints.job import ns as job_namespace
 from api.endpoints.wmts import ns as wmts_namespace
+from api.endpoints.wms import ns as wms_namespace
 from api.endpoints.members import ns as members_namespace
 from api.restplus import api
 import jwt
@@ -84,6 +85,7 @@ def initialize_app(flask_app):
     api.add_namespace(algorithm_namespace)
     api.add_namespace(job_namespace)
     api.add_namespace(wmts_namespace)
+    api.add_namespace(wms_namespace)
     api.add_namespace(members_namespace)
     flask_app.register_blueprint(blueprint)
 

--- a/api/settings.py
+++ b/api/settings.py
@@ -2,7 +2,7 @@
 APP_AUTH_KEY = "thisisthesecretkey"
 
 # Flask settings
-FLASK_SERVER_NAME = 'localhost:5000'
+FLASK_SERVER_NAME = 'http://localhost:5000'
 FLASK_DEBUG = True  # Do not use debug mode in production
 
 # Flask-Restplus settings

--- a/api/utils/mapproxy_snap.py
+++ b/api/utils/mapproxy_snap.py
@@ -1,0 +1,255 @@
+import copy
+import requests
+from io import StringIO
+
+from PIL import Image, ImageChops
+from mapproxy.request import Request
+from mapproxy.config.loader import ProxyConfiguration
+from owslib.wmts import WebMapTileService
+from natsort import natsorted
+from requests_file import FileAdapter
+
+from owslib.wmts import TileMatrix, testXMLValue, _TILE_MATRIX_TAG, _IDENTIFIER_TAG, _SCALE_DENOMINATOR_TAG, \
+    _TOP_LEFT_CORNER_TAG, _TILE_WIDTH_TAG, _TILE_HEIGHT_TAG, _MATRIX_WIDTH_TAG, _MATRIX_HEIGHT_TAG
+
+
+def tilematrixinit(self, elem):
+    if elem.tag != _TILE_MATRIX_TAG:
+        raise ValueError('%s should be a TileMatrix' % (elem,))
+    self.identifier = testXMLValue(elem.find(_IDENTIFIER_TAG)).strip()
+    sd = testXMLValue(elem.find(_SCALE_DENOMINATOR_TAG))
+    if sd is None:
+        raise ValueError('%s is missing ScaleDenominator' % (elem,))
+    self.scaledenominator = float(sd)
+    tl = testXMLValue(elem.find(_TOP_LEFT_CORNER_TAG))
+    if tl is None:
+        raise ValueError('%s is missing TopLeftCorner' % (elem,))
+    (lon, lat) = tl.split(" ")
+    self.topleftcorner = (float(lon), float(lat))
+    width = testXMLValue(elem.find(_TILE_WIDTH_TAG))
+    height = testXMLValue(elem.find(_TILE_HEIGHT_TAG))
+    if (width is None) or (height is None):
+        msg = '%s is missing TileWidth and/or TileHeight' % (elem,)
+        raise ValueError(msg)
+    self.tilewidth = int(width)
+    self.tileheight = int(height)
+    mw = testXMLValue(elem.find(_MATRIX_WIDTH_TAG))
+    mh = testXMLValue(elem.find(_MATRIX_HEIGHT_TAG))
+    if (mw is None) or (mh is None):
+        msg = '%s is missing MatrixWidth and/or MatrixHeight' % (elem,)
+        raise ValueError(msg)
+    self.matrixwidth = int(float(mw)) # Fix here, Lunar xml files have decimals which causes int() to error
+    self.matrixheight = int(float(mh)) # Fix here, Lunar xml files have decimals which causes int() to error
+
+
+def request(method, url, **kwargs):
+    """
+    This method is to override the requests.request library method so that it will accept local files. Please see the
+    documentation/code for requests.request (in api.py) for more information.
+    :param method:
+    :param url:
+    :param kwargs:
+    :return:
+    """
+    with requests.sessions.Session() as session:
+        session.mount('file://', FileAdapter())
+        return session.request(method=method, url=url, **kwargs)
+
+
+def create_config_wmts(serviceurls, layernames=()):
+    """
+    This method creates an in-memory version of the mapproxy configuration file, derived from the GetCapabilities
+    xml file. This has only been tested on OnEarth-based tile servers such as GIBS and PO.DAAC.
+    :param serviceurls: A list of URIs to xml files or wmts service endpoints.
+    :param layernames: An optional list of layer names, otherwise it will create a config file with all layers.
+    :return: The in-memory version of the mapproxy configuration file.
+    """
+    requests.request = request  # do the ugly hack
+    TileMatrix.__init__ = tilematrixinit # do more ugly hacks
+
+    # An empty configuration file with known defaults
+    mapproxy_conf = {
+        'services': {
+            'wms': {
+                'srs': ['EPSG:4326'],
+                'max_output_pixels': [6000, 6000],
+                'image_formats': ['image/jpeg', 'image/jpg', 'image/png']
+            }
+        },
+        'layers': [],
+        'caches': {},
+        'sources': {},
+        'grids': {},
+        'globals': {
+            'image': {
+                'resampling_method': 'bicubic',
+                'formats': {
+                    'image/png': {
+                        'mode': 'RGBA',
+                        'colors': 0,
+                        'resampling_method': 'bicubic'
+                    },
+                    'image/jpeg': {
+                        'mode': 'RGB',
+                        'colors': 0,
+                        'resampling_method': 'bicubic',
+                        'encoding_options': {
+                            'jpeg_quality': 90
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    wmtsconfs = []
+    for serviceurl in serviceurls:
+        wmtsconfs.append(WebMapTileService(serviceurl))
+
+    if len(layernames) == 0:
+        layernames = []
+        for wmtsconf in wmtsconfs:
+            layernames += wmtsconf.contents.keys()
+        layernames = sorted(layernames)
+
+    for layername in layernames:
+        foundlayer = False
+
+        for wmtsconf in wmtsconfs:
+            if layername in wmtsconf.contents:
+                foundlayer = True
+
+                cachekey = layername + "_Cache"
+                sourcekey = layername + "_Source"
+                tilematrixsetkey = list(wmtsconf.contents[layername].tilematrixsetlinks.keys())[0]
+                gridkey = layername + "_Grid"
+                # Ideally the gridkey is the same as the tilematrixset name. However, when we're combining
+                # GetCapabilities files, there may be grids that have the same name, but have different levels of zoom
+                # thus each now needs to be unique. That's why there's a gridkey and tilematrixsetkey.
+
+                if gridkey not in mapproxy_conf['grids']:
+                    # Generate grid
+                    # https://help.openstreetmap.org/questions/9510/understanding-scale
+                    magicnumber = 397569610  # see OSM article regarding scale
+                    tilematrixset = wmtsconf.tilematrixsets[tilematrixsetkey]
+                    tilematrixsetkeys = natsorted(tilematrixset.tilematrix.keys())
+                    firsttilematrix = tilematrixset.tilematrix[tilematrixsetkeys[0]]
+                    gridtilesize = [firsttilematrix.tilewidth, firsttilematrix.tileheight]
+                    
+                    if tilematrixset.crs == "urn:ogc:def:crs:EPSG:6.18.3:3857":
+                        mapproxy_conf['grids'][gridkey] = {
+                            'base': 'GLOBAL_WEBMERCATOR',
+                            'tile_size': gridtilesize
+                        }
+                    else:
+
+                        gridres = []
+
+                        for tilematrixsetid in tilematrixsetkeys:
+                            tilematrix = tilematrixset.tilematrix[tilematrixsetid]
+                            sd = tilematrix.scaledenominator
+                            gridres.append(round(sd / magicnumber, 12))
+
+                        gridbbox = [int(round(firsttilematrix.topleftcorner[0])),
+                                    int(round(firsttilematrix.topleftcorner[1] - (gridres[0] * gridtilesize[0]))),
+                                    int(round(firsttilematrix.topleftcorner[0] + 2 * (gridres[0] * gridtilesize[0]))),
+                                    int(round(firsttilematrix.topleftcorner[1]))]
+
+                        mapproxy_conf['grids'][gridkey] = {
+                            'srs': 'EPSG:4326',
+                            'bbox': gridbbox,
+                            'tile_size': gridtilesize,
+                            'res': gridres,
+                            'origin': 'ul'
+                        }
+
+                urltemplate = wmtsconf.contents[layername].resourceURLs[0]['template']
+                url = urltemplate.replace(
+                    '{TileCol}', '%(x)s').replace('{TileRow}', '%(y)s').replace(
+                    '{TileMatrix}', '%(z)s').replace('{TileMatrixSet}', tilematrixsetkey).replace(
+                    '{Style}', list(wmtsconf.contents[layername].styles.keys())[0])
+
+                sourcetransparency = False
+                sourceformat = wmtsconf.contents[layername].formats[0].lower()
+                if sourceformat == 'image/png':
+                    sourcetransparency = True
+
+                mapproxy_conf['sources'][sourcekey] = {
+                    'type': 'tile',
+                    'url': url,
+                    'grid': gridkey,
+                    'transparent': sourcetransparency,
+                    'http': {
+                        'ssl_no_cert_checks': True
+                    },
+                    'coverage': {
+                        'bbox': wmtsconf.contents[layername].boundingBoxWGS84,
+                        'srs': 'EPSG:4326'
+                    }
+                }
+
+                mapproxy_conf['caches'][cachekey] = {
+                    'grids': [gridkey],
+                    'sources': [sourcekey],
+                    'format': sourceformat,
+                    'disable_storage': True
+                }
+
+                mapproxy_conf['layers'].append({
+                    'name': layername,
+                    'title': layername,
+                    'sources': [cachekey]
+                })
+
+        if not foundlayer:
+            raise ValueError("Layer not found!", layername)
+
+    return mapproxy_conf
+
+
+def mapit(mapproxy_conf, layername, outputmimeformat, lonlatbbox, imagesize, outputfilename=None, time=None):
+    """
+    This automates the creation of a map image.
+    :param mapproxy_conf: The mapproxy in-memory configuration dictionary.
+    :param layername: The name of the layer to image.
+    :param outputmimeformat: The mime format (i.e. image/png, image/jpeg) of the output
+    :param lonlatbbox: The bounding box as a tuple, (west, south, east, north)
+    :param imagesize: The images size as a tuple, (width, height)
+    :param outputfilename: An optional output filename, if None, then no file will be written.
+    :param time: An optional time string for layers that have the time dimension
+    :return: The binary data for the image generated.
+    """
+    if time is None:
+        time = ''
+    mapproxy_conf = copy.deepcopy(mapproxy_conf)  # dup it for replacing time
+    for source in mapproxy_conf['sources']:
+        mapproxy_conf['sources'][source]['url'] = mapproxy_conf['sources'][source]['url'].replace("{Time}", time)
+
+    transparent = 'false'
+    if 'png' in outputmimeformat.lower():
+        transparent = 'true'
+
+    querystring = "LAYERS=%s&FORMAT=%s&SRS=EPSG:4326&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&TRANSPARENT=%s&STYLES=&BBOX=%f,%f,%f,%f&WIDTH=%d&HEIGHT=%d" % (
+        layername, outputmimeformat, transparent, lonlatbbox[0], lonlatbbox[1], lonlatbbox[2], lonlatbbox[3],
+        imagesize[0],
+        imagesize[1])
+
+    conf = ProxyConfiguration(mapproxy_conf, conf_base_dir='', seed=False, renderd=False)
+
+    services = conf.configured_services()
+
+    myreq = {
+        'QUERY_STRING': querystring,
+        'SERVER_NAME': '',
+        'SERVER_PORT': '',
+        'wsgi.url_scheme': '',
+    }
+
+    response = services[0].handle(Request(myreq))
+    data = response.data
+
+    if outputfilename:
+        f = open(outputfilename, "w")
+        f.write(data)
+    return data
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,9 @@ gitpython~=2.1.11
 PyJWT~=1.7.1
 xmltodict~=0.12.0
 flask-cas-ng~=1.1.0
+mapproxy~=1.11.0
+owslib~=0.18.0
+requests_file~=1.4.3
+natsort~=6.0.0
+pillow~=6.1.0
+pyproj==1.9.6


### PR DESCRIPTION
Adds a WMS `GetMap` endpoint which relies on `mapproxy_snap.py` to generate an image using WMTS GetCapabilities and GetTile.

Testing:
* Ran a local instance of maap-api-nasa
* Ran a openlayers service, see https://github.com/abarciauskas-bgse/maap-openlayers-testing

<img width="934" alt="Screen Shot 2019-08-01 at 6 07 31 PM" src="https://user-images.githubusercontent.com/15016780/62330637-43a54500-b487-11e9-8df8-eabbd6dbc1e8.png">
