### PR TITLE
Add query service endpoint

### DIFF
--- a/api/endpoints/query_service.py
+++ b/api/endpoints/query_service.py
@@ -3,7 +3,7 @@ import logging
 import uuid
 
 import boto3
-from flask import jsonify, request
+from flask import jsonify, request, redirect
 from flask_restplus import Resource
 
 from api.restplus import api
@@ -11,7 +11,7 @@ import api.settings as settings
 
 log = logging.getLogger(__name__)
 
-ns = api.namespace('query-service', description='Operations for Query Service')
+ns = api.namespace('query', description='Operations for Query Service')
 
 s3_client = boto3.client('s3')
 sf_client = boto3.client('stepfunctions')
@@ -36,7 +36,7 @@ def err_response(msg, code=400):
     }, code
 
 
-@ns.route('/query')
+@ns.route('/')
 class QueryServiceCreate(Resource):
 
     def _is_valid_fields(self, fields):
@@ -127,7 +127,6 @@ class QueryServiceCreate(Resource):
             )
 
         src = req_data.get('src') or {}
-        print('src', src)
         if not self._is_valid_src(src):
             return err_response(
                 "'src' property failed to validate as a Collection or Granule object."
@@ -157,21 +156,11 @@ class QueryServiceCreate(Resource):
         )
 
 
-@ns.route('/query/<string:query_id>')
+@ns.route('/<string:query_id>')
 class QueryServiceResults(Resource):
 
     def get(self, query_id):
         """
-        Get query results
+        Return redirect to query results
         """
-        return get_signed_url(query_id)
-
-
-@ns.route('/query/<string:query_id>/meta')
-class QueryServiceMetadata(Resource):
-
-    def get(self, query_id):
-        """
-        Get query metadata
-        """
-        return get_signed_url(f"{query_id}.meta")
+        return redirect(get_signed_url(query_id), code=302)

--- a/api/endpoints/query_service.py
+++ b/api/endpoints/query_service.py
@@ -1,0 +1,137 @@
+import json
+import logging
+import uuid
+
+import boto3
+from flask import jsonify, request
+from flask_restplus import Resource
+
+from api.restplus import api
+import api.settings as settings
+
+log = logging.getLogger(__name__)
+
+ns = api.namespace('query-service', description='Operations for Query Service')
+
+s3_client = boto3.client('s3')
+sf_client = boto3.client('stepfunctions')
+
+
+def get_signed_url(query_id: str, expiration: int = 60 * 60 * 24):
+    return s3_client.generate_presigned_url(
+        'get_object',
+        Params={
+            'Bucket': settings.QS_RESULT_BUCKET,
+            'Key': query_id
+        },
+        ExpiresIn=expiration
+    )
+
+
+def err_response(msg, code=400):
+    return {
+        'code': code,
+        'message': msg
+    }, code
+
+
+@ns.route('/query')
+class QueryServiceCreate(Resource):
+
+    def _is_valid_fields(self, fields):
+        return all([isinstance(f, str) for f in fields])
+
+    def _is_valid_bbox(self, bbox):
+        return all([
+            len(bbox) is 4,
+            *[isinstance(f, float) or isinstance(f, int) for f in bbox]
+        ])
+
+    def _is_valid_src(self, src):
+        return any([
+            self._contains_valid_collection(src),
+            self._contains_valid_granule(src)
+        ])
+
+    def _contains_valid_collection(self, src):
+        collection = src.get('Collection')
+        if not isinstance(collection, object):
+            return False
+        return all([
+            isinstance(collection.get('ShortName'), str),
+            isinstance(collection.get('VersionId'), str)
+        ])
+
+    def _contains_valid_granule(self, src):
+        granule = src.get('Granule')
+        if not isinstance(granule, object):
+            return False
+        return all([
+            self._contains_valid_collection(granule),
+            isinstance(granule.get('GranuleUR'), str),
+        ])
+
+    def post(self):
+        """
+        Create query execution
+        """
+        req_data = request.get_json()
+
+        fields = req_data.get('fields') or []
+        if fields and not self._is_valid_fields(fields):
+            return err_response("Optional 'fields' property must be array of field names")
+
+        bbox = req_data.get('bbox') or []
+        if bbox and not self._is_valid_bbox(bbox):
+            return err_response(
+                "Optional 'bbox' property must be a GeoJSON compliant bbox, an array of 4 numbers"
+            )
+
+        src = req_data.get('src', {})
+        if not self._is_valid_src(src):
+            return err_response(
+                "'src' property failed to validate as a Collection or Granule object."
+            )
+
+        # Schedule execution
+        query_id = str(uuid.uuid4())
+        query_input = {
+            'id': query_id,
+            'src': src,
+            'query': {
+                'fields': fields,
+                'bbox': bbox
+            }
+        }
+        sf_client.start_execution(
+            stateMachineArn=settings.QS_STATE_MACHINE_ARN,
+            name=query_id,
+            input=json.dumps(query_input)
+        )
+
+        # Return signed response URL to query results
+        return jsonify(
+            id=query_id,
+            url=get_signed_url(query_id),
+            meta=get_signed_url(f'{query_id}.meta')
+        )
+
+
+@ns.route('/query/<string:query_id>')
+class QueryServiceResults(Resource):
+
+    def get(self, query_id):
+        """
+        Get query results
+        """
+        return get_signed_url(query_id)
+
+
+@ns.route('/query/<string:query_id>/meta')
+class QueryServiceMetadata(Resource):
+
+    def get(self, query_id):
+        """
+        Get query metadata
+        """
+        return get_signed_url(f"{query_id}.meta")

--- a/api/maapapp.py
+++ b/api/maapapp.py
@@ -11,6 +11,7 @@ from api.endpoints.algorithm import ns as algorithm_namespace
 from api.endpoints.job import ns as job_namespace
 from api.endpoints.wmts import ns as wmts_namespace
 from api.endpoints.members import ns as members_namespace
+from api.endpoints.query_service import ns as query_service_namespace
 from api.restplus import api
 import jwt
 import datetime
@@ -19,7 +20,8 @@ from flask_cas import CAS
 app = Flask(__name__)
 cas = CAS(app)
 app.secret_key = settings.CAS_SECRET_KEY
-logging_conf_path = os.path.normpath(os.path.join(os.path.dirname(__file__), '../logging.conf'))
+logging_conf_path = os.path.normpath(os.path.join(
+    os.path.dirname(__file__), '../logging.conf'))
 logging.config.fileConfig(logging_conf_path)
 log = logging.getLogger(__name__)
 
@@ -52,11 +54,12 @@ def issue_token(username, password):
 
     # Until MAAP account integration is in place, just verify user's URS authorization
     if response.status_code == 200 or response.status_code == 201:
-        token = jwt.encode({'user' : username, 'exp' : datetime.datetime.utcnow() + datetime.timedelta(weeks=24)}, settings.APP_AUTH_KEY)
+        token = jwt.encode({'user': username, 'exp': datetime.datetime.utcnow(
+        ) + datetime.timedelta(weeks=24)}, settings.APP_AUTH_KEY)
 
-        return jsonify({'token' : token.decode('UTF-8')})
+        return jsonify({'token': token.decode('UTF-8')})
 
-    return make_response('Could not verify!', 401, {'WWW-Authenticate' : 'Basic realm="Login Required"'})
+    return make_response('Could not verify!', 401, {'WWW-Authenticate': 'Basic realm="Login Required"'})
 
 
 @app.route('/')
@@ -73,6 +76,8 @@ def configure_app(flask_app):
     flask_app.config['RESTPLUS_MASK_SWAGGER'] = settings.RESTPLUS_MASK_SWAGGER
     flask_app.config['ERROR_404_HELP'] = settings.RESTPLUS_ERROR_404_HELP
     flask_app.config['TILER_ENDPOINT'] = settings.TILER_ENDPOINT
+    flask_app.config['QS_STATE_MACHINE_ARN'] = settings.QS_STATE_MACHINE_ARN
+    flask_app.config['QS_RESULT_BUCKET'] = settings.QS_RESULT_BUCKET
 
 
 def initialize_app(flask_app):
@@ -85,17 +90,17 @@ def initialize_app(flask_app):
     api.add_namespace(job_namespace)
     api.add_namespace(wmts_namespace)
     api.add_namespace(members_namespace)
+    api.add_namespace(query_service_namespace)
     flask_app.register_blueprint(blueprint)
 
 
 def main():
     initialize_app(app)
-    #service
-    log.info('>>>>> Starting development server at http://{}/api/ <<<<<'.format(app.config['SERVER_NAME']))
+    # service
+    log.info(
+        '>>>>> Starting development server at http://{}/api/ <<<<<'.format(app.config['SERVER_NAME']))
     app.run(debug=settings.FLASK_DEBUG)
 
 
 if __name__ == "__main__":
     main()
-
-

--- a/api/settings.py
+++ b/api/settings.py
@@ -48,3 +48,6 @@ CAS_SECRET_KEY = ''
 CAS_SERVER_NAME = ''
 CAS_AFTER_LOGIN = 'profile'
 
+# Query Service
+QS_STATE_MACHINE_ARN = "arn:aws:states:us-east-1:532321095167:stateMachine:maap-api-query-service-dev-RunQuery"
+QS_RESULT_BUCKET = "maap-api-query-service-dev-query-results"

--- a/dockerfile
+++ b/dockerfile
@@ -1,4 +1,4 @@
-FROM python
+FROM python:3.6
 
 WORKDIR /maap-api-nasa
 COPY . .

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,7 @@
+FROM python
+
+WORKDIR /maap-api-nasa
+COPY . .
+COPY api/settings.py api/settings.py
+RUN pip3 install -r requirements.txt
+CMD FLASK_APP=api/maapapp.py flask run --host=0.0.0.0

--- a/maap-skeleton.yaml
+++ b/maap-skeleton.yaml
@@ -10,7 +10,7 @@ consumes:
   - application/json
 produces:
   - application/json
-  
+
 paths:
 
   /info:
@@ -19,17 +19,17 @@ paths:
         - Info
       description: Get information about the MAAP service !
       operationId: get_service_info
-       
+
       responses:
         200:
           description: Service info
           schema:
-            $ref: "#/definitions/ServiceInfo"          
+            $ref: "#/definitions/ServiceInfo"
         default:
           description: Error
           schema:
             $ref: "#/definitions/ErrorResponse"
-            
+
   /workspace:
     get:
       tags:
@@ -44,7 +44,7 @@ paths:
         default:
           description: Error
           schema:
-            $ref: "#/definitions/ErrorResponse" 
+            $ref: "#/definitions/ErrorResponse"
     post:
       tags:
         - Workspace
@@ -55,7 +55,7 @@ paths:
           in: body
           required: true
           schema:
-            $ref: "#/definitions/WorkspaceInput"             
+            $ref: "#/definitions/WorkspaceInput"
       responses:
         200:
           description: New workspace
@@ -64,21 +64,21 @@ paths:
         default:
           description: Error
           schema:
-            $ref: "#/definitions/ErrorResponse"   
- 
+            $ref: "#/definitions/ErrorResponse"
+
   /jobs:
     get:
       tags:
         - Job
       description: Get list of jobs
       operationId: get_jobs
-       
+
       responses:
         200:
           description: List of jobs
           schema:
             type: array
-            items: 
+            items:
               $ref: "#/definitions/Job"
         default:
           description: Error
@@ -95,7 +95,7 @@ paths:
           in: body
           required: true
           schema:
-            $ref: "#/definitions/JobInput"             
+            $ref: "#/definitions/JobInput"
       responses:
         200:
           description: New job
@@ -104,7 +104,7 @@ paths:
         default:
           description: Error
           schema:
-            $ref: "#/definitions/ErrorResponse"            
+            $ref: "#/definitions/ErrorResponse"
   /jobs/{job_id}:
     get:
       tags:
@@ -116,7 +116,7 @@ paths:
           in: path
           description: unique id of job
           type: string
-          required: true      
+          required: true
       responses:
         200:
           description: Job info
@@ -125,8 +125,8 @@ paths:
         default:
           description: Error
           schema:
-            $ref: "#/definitions/ErrorResponse"            
-            
+            $ref: "#/definitions/ErrorResponse"
+
   /jobs/{job_id}/submit:
     post:
       tags:
@@ -138,7 +138,7 @@ paths:
           in: path
           description: unique id of job
           type: string
-          required: true        
+          required: true
       responses:
         200:
           description: Successful submission
@@ -213,7 +213,7 @@ paths:
         default:
           description: Error
           schema:
-            $ref: "#/definitions/ErrorResponse"  
+            $ref: "#/definitions/ErrorResponse"
 
   /algorithms:
     get:
@@ -221,13 +221,13 @@ paths:
         - Algorithm
       description: Get list of algorithms
       operationId: get_algorithms
-       
+
       responses:
         200:
           description: List of algorithms
           schema:
             type: array
-            items: 
+            items:
               $ref: "#/definitions/Algorithm"
         default:
           description: Error
@@ -244,7 +244,7 @@ paths:
           in: body
           required: true
           schema:
-            $ref: "#/definitions/AlgorithmInput"             
+            $ref: "#/definitions/AlgorithmInput"
       responses:
         200:
           description: New algorithm
@@ -253,7 +253,7 @@ paths:
         default:
           description: Error
           schema:
-            $ref: "#/definitions/ErrorResponse"            
+            $ref: "#/definitions/ErrorResponse"
   /algorithms/{algorithm_id}:
     get:
       tags:
@@ -265,7 +265,7 @@ paths:
           in: path
           description: unique id of algorithm
           type: string
-          required: true      
+          required: true
       responses:
         200:
           description: Algorithm info
@@ -274,8 +274,8 @@ paths:
         default:
           description: Error
           schema:
-            $ref: "#/definitions/ErrorResponse"            
-     
+            $ref: "#/definitions/ErrorResponse"
+
   /collections:
     post:
       tags:
@@ -287,7 +287,7 @@ paths:
           in: body
           required: true
           schema:
-            $ref: "#/definitions/CollectionInput"             
+            $ref: "#/definitions/CollectionInput"
       responses:
         200:
           description: New collection
@@ -296,7 +296,7 @@ paths:
         default:
           description: Error
           schema:
-            $ref: "#/definitions/ErrorResponse"            
+            $ref: "#/definitions/ErrorResponse"
   /collections/{collection_id}:
     get:
       tags:
@@ -308,7 +308,7 @@ paths:
           in: path
           description: unique id of collection
           type: string
-          required: true      
+          required: true
       responses:
         200:
           description: Collection info
@@ -317,7 +317,7 @@ paths:
         default:
           description: Error
           schema:
-            $ref: "#/definitions/ErrorResponse"  
+            $ref: "#/definitions/ErrorResponse"
     delete:
       tags:
         - Collection
@@ -328,13 +328,13 @@ paths:
           in: path
           description: unique id of collection
           type: string
-          required: true      
+          required: true
       responses:
         default:
           description: Error
           schema:
-            $ref: "#/definitions/ErrorResponse"             
-     
+            $ref: "#/definitions/ErrorResponse"
+
   /granules:
     post:
       tags:
@@ -346,7 +346,7 @@ paths:
           in: body
           required: true
           schema:
-            $ref: "#/definitions/GranuleInput"             
+            $ref: "#/definitions/GranuleInput"
       responses:
         200:
           description: New granule
@@ -355,7 +355,7 @@ paths:
         default:
           description: Error
           schema:
-            $ref: "#/definitions/ErrorResponse"            
+            $ref: "#/definitions/ErrorResponse"
   /granules/{granule_id}:
     get:
       tags:
@@ -367,7 +367,7 @@ paths:
           in: path
           description: unique id of granule
           type: string
-          required: true      
+          required: true
       responses:
         200:
           description: Granule info
@@ -376,41 +376,47 @@ paths:
         default:
           description: Error
           schema:
-            $ref: "#/definitions/ErrorResponse"  
-    delete:
+            $ref: "#/definitions/ErrorResponse"
+
+  /query:
+    post:
       tags:
-        - Granule
-      description: Delete a granule
-      operationId: delete_granule
+        - Query
+      description: Create a asynchronous query
+      operationId: create_query
       parameters:
-        - name: granule_id
-          in: path
-          description: unique id of granule
-          type: string
-          required: true      
-      responses:
-        default:
-          description: Error
+        - name: query_input
+          in: body
+          required: true
           schema:
-            $ref: "#/definitions/ErrorResponse"       
-  
+            $ref: "#/definitions/QueryInput"
+      # responses:
+      #   200:
+      #     description: Query Links
+      #     schema:
+      #       $ref: "#/definitions/QueryLink"
+      #   default:
+      #     description: Error
+      #     schema:
+      #       $ref: "#/definitions/ErrorResponse"
+
 definitions:
   ServiceInfo:
-    description: Information about the MAAP service  
+    description: Information about the MAAP service
     properties:
       name:
         type: string
         description: name of the service
       description:
         type: string
-        description: Description of the service        
+        description: Description of the service
       version:
         type: string
         description: version of the service
       subsytems:
-        type: array      
+        type: array
         items:
-          $ref: "#/definitions/SubsytemInfo"          
+          $ref: "#/definitions/SubsytemInfo"
 
   SubsytemInfo:
     description: Information about the subsystem api
@@ -420,21 +426,21 @@ definitions:
         description: name of the subsytem
       description:
         type: string
-        description: Description of the subsytem        
+        description: Description of the subsytem
       version:
         type: string
         description: version of the subsytem
       uri:
         type: string
         description: uri location of the subsytem
-        
+
   WorkspaceInput:
     description: Input to create a new workspace
     properties:
       workspace_name:
         type: string
         description: name of the workspace
-        
+
   Workspace:
     description: Jobs, algorithms, and user-specific work
     allOf:
@@ -445,22 +451,22 @@ definitions:
           type: string
           description: unique id of the algorithm
       jobs:
-        type: array      
+        type: array
         items:
-          $ref: "#/definitions/Job" 
+          $ref: "#/definitions/Job"
       algorithms:
-        type: array      
+        type: array
         items:
-          $ref: "#/definitions/Algorithm" 
+          $ref: "#/definitions/Algorithm"
       collections:
-        type: array      
+        type: array
         items:
-          $ref: "#/definitions/Collection" 
+          $ref: "#/definitions/Collection"
       granules:
-        type: array      
+        type: array
         items:
-          $ref: "#/definitions/Granule" 
-        
+          $ref: "#/definitions/Granule"
+
   AlgorithmInput:
     description: input to create a new algorithm
     properties:
@@ -469,14 +475,14 @@ definitions:
         description: name of the algorithm
       algorithm_uri:
         type: string
-        description: Unique uri of the algorithm 
+        description: Unique uri of the algorithm
       algorithm_branch:
         type: string
         description: Branch name of the algorithm
       algorithm_version:
         type: string
-        description: Version of the algorithm 
-        
+        description: Version of the algorithm
+
   Algorithm:
     allOf:
     - $ref: "#/definitions/AlgorithmInput"
@@ -485,7 +491,7 @@ definitions:
       algorithm_id:
           type: string
           description: unique id of the algorithm
-        
+
   JobInput:
     description: input to create a new job
     properties:
@@ -496,9 +502,9 @@ definitions:
         type: string
         description: id of the algorithm
       data_collection:
-        type: array      
+        type: array
         items:
-          $ref: "#/definitions/Granule" 
+          $ref: "#/definitions/Granule"
       status:
         type: string
         description: status of the job
@@ -506,10 +512,10 @@ definitions:
           - ACTIVE
           - DEPRECATED
       description:
-        type: string      
+        type: string
         description: description of the job
-        
-  Job:      
+
+  Job:
     allOf:
     - $ref: "#/definitions/JobInput"
     - type: object
@@ -630,14 +636,13 @@ definitions:
       description:
         type: string
         description: descripton of the file
-        
+
   CollectionInput:
     properties:
       description:
         type: string
         description: descripton of the collection
-        
-        
+
   Collection:
     allOf:
     - $ref: '#/definitions/CollectionInput'
@@ -646,13 +651,13 @@ definitions:
       collection_id:
         type: string
         description: Id of the granule
-        
+
   GranuleInput:
     properties:
       description:
         type: string
         description: descripton of the granule
-        
+
   Granule:
     allOf:
     - $ref: '#/definitions/GranuleInput'
@@ -661,7 +666,39 @@ definitions:
       granule_id:
         type: string
         description: Id of the granule
-        
+
+  QueryInput:
+    properties:
+    id:
+      type: string
+    src:
+      type: object
+      description: "Either a Collection"
+    query:
+      type: object
+      properties:
+      fields:
+        description: "Fields to be returned from dataset. If omitted, all fields will be returned"
+        type: array
+        items:
+        type: array
+      bbox:
+        description: "A GeoJSON-compliant 2D bounding box (https://tools.ietf.org/html/rfc7946#section-5)"
+        type: array
+        items:
+        - type: number
+          description: "X Min"
+        - type: number
+          description: "Y Min"
+        - type: number
+          description: "X Max"
+        - type: number
+          description: "Y Max"
+    required:
+    - id
+    - src
+    - query
+
   ErrorResponse:
     required:
     - message
@@ -671,15 +708,15 @@ definitions:
 
 
 parameters:
-    
+
   offset:
-    name: offset    
+    name: offset
     in: query
     description: Start index for pagination. zero based.
     required: false
     type: integer
     default: 0
-    
+
   limit:
     name: limit
     in: query
@@ -687,4 +724,4 @@ parameters:
     required: false
     type: integer
     default: 50
-  
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ gitpython~=2.1.11
 PyJWT~=1.7.1
 xmltodict~=0.12.0
 flask-cas-ng~=1.1.0
-boto3==1.9.184
+boto3==1.9.199

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ gitpython~=2.1.11
 PyJWT~=1.7.1
 xmltodict~=0.12.0
 flask-cas-ng~=1.1.0
+boto3==1.9.184


### PR DESCRIPTION
In this PR, I've added a simple `query` namespace with two endpoints:

- `/`: `POST` to create query, returns object to direct user to results:
    ```
    {
        "meta": "https://maap-api-query-service-dev-query-results.s3.amazonaws.com/b26ff422-992d-4770-8d03-b8f768220425.meta?AWSAccessKeyId=AKIAXX4GPJX7275AG6EP&Signature=mHpHR3uI9YvMWdLF45Ve40MzO7w%3D&Expires=1564786217",
        "id": "b26ff422-992d-4770-8d03-b8f768220425",
        "results": "https://maap-api-query-service-dev-query-results.s3.amazonaws.com/b26ff422-992d-4770-8d03-b8f768220425?AWSAccessKeyId=AKIAXX4GPJX7275AG6EP&Signature=Xqmx6e0tS2yiE7xEr5VOGIDaQg0%3D&Expires=1564786217"
    }
    ```
- `/<id>`: Returns a `302` redirect to the results location.

I've added some crude validation for the input object.

I added the `QS_STATE_MACHINE_ARN` setting to the app's configuration, although I'm not sure why that's necessary being that I only ever import the setting directly from the `settings` module.

I added @abarciauskas-bgse's docker file for future developer's needs.

When deploying this code to production, it's important that the EC2 machine (or however it's deployed) has the appropriate IAM role allowing it to both access files within the `QS_RESULT_BUCKET` S3 bucket and to execute the `QS_STATE_MACHINE_ARN` step function.

Sorry for all the whitespace changes, my editor does that automatically on save.  I can remove those at your request.  Otherwise, you can ignore those in this PR by appending `?w=1` to the URL.