### PR TITLE
Configurable wms layers

### DIFF
--- a/api/endpoints/wms.py
+++ b/api/endpoints/wms.py
@@ -24,16 +24,10 @@ class GetMap(Resource):
         try:
             wmts_getcapabilities_filename = 'maap.wmts.xml'
 
-            # TODO(Aimee): This avoids an error response from CMR "Parameter [service]
-            # was not recognized" but we probably want a longer list of permitted
-            # params.
-            cmr_search_params_whitelist = ['granule_ur', 'short_name', 'version']
-            cmr_search_params = {}
-            for key in cmr_search_params_whitelist:
-                if key in request.args:
-                   cmr_search_params[key] = request.args[key]
+            # Pass param which can be used to generate GetCapabilities dynamically
+            cmr_search_params = {'granule_ur': request.args['LAYERS']}
 
-            # TODO(Aimee): This generates a local copy of WMTS GetCapabilities
+            # Review(Aimee): This generates a local copy of WMTS GetCapabilities
             # XML, which `create_config_wmts` requires. `create_config_wmts`
             # could also call the /wmts/GetCapabilities endpoint but it would
             # run the same code to generate the XML so the tradeoff is making a
@@ -50,7 +44,7 @@ class GetMap(Resource):
             # as STYLE. Also, multiple layers could be passed.
             bbox = tuple(map(float, request.args['BBOX'].split(',')))
             size = (int(request.args['HEIGHT']), int(request.args['WIDTH']))
-            layer = request.args['LAYERS']
+            layer = request.args['LAYERS'].replace(':', '')
             img_format = request.args['FORMAT']
 
             # Create the image

--- a/api/endpoints/wms.py
+++ b/api/endpoints/wms.py
@@ -50,7 +50,7 @@ class GetMap(Resource):
             # as STYLE. Also, multiple layers could be passed.
             bbox = tuple(map(float, request.args['BBOX'].split(',')))
             size = (int(request.args['HEIGHT']), int(request.args['WIDTH']))
-            layer = request.args['LAYERS'][0]
+            layer = request.args['LAYERS']
             img_format = request.args['FORMAT']
 
             # Create the image

--- a/api/endpoints/wms.py
+++ b/api/endpoints/wms.py
@@ -44,6 +44,9 @@ class GetMap(Resource):
             # as STYLE. Also, multiple layers could be passed.
             bbox = tuple(map(float, request.args['BBOX'].split(',')))
             size = (int(request.args['HEIGHT']), int(request.args['WIDTH']))
+            # FIXME: One collection (AFLVIS2) has granule urs which include
+            # a colon, which causes a mapproxy configuration error.
+            # Example: SC:AFLVIS2.001:138348873. This also shows up in wmts.py.
             layer = request.args['LAYERS'].replace(':', '')
             img_format = request.args['FORMAT']
 

--- a/api/endpoints/wmts.py
+++ b/api/endpoints/wmts.py
@@ -179,8 +179,8 @@ class GetCapabilities(Resource):
             stats_resp = get_stats(urls_query_string, ','.join(map(str, bbox)))
             stats = stats_resp['statistics']['1']
             std = stats['std']
-            min_scale = stats['min'] - (2*std)
-            max_scale = stats['min'] + (2*std)
+            min_scale = stats['min']
+            max_scale = stats['min'] + (3*std)
             rescale = ','.join([str(min_scale), str(max_scale)])
 
         layer_info = {

--- a/api/endpoints/wmts.py
+++ b/api/endpoints/wmts.py
@@ -211,6 +211,9 @@ class GetCapabilities(Resource):
         if len(request_args) > 0:
             layer_title = 'search_results'
             if 'granule_ur' in request_args:
+                # FIXME: One collection (AFLVIS2) has granule urs which include
+                # a colon, which causes a mapproxy configuration error.
+                # Example: SC:AFLVIS2.001:138348873. This also shows up in wms.py.
                 layer_title = request_args['granule_ur'].replace(':', '')
             urls = get_cog_urls_string(request_args)
             layers.append(self.generate_layer_info(layer_title, urls))

--- a/api/endpoints/wmts.py
+++ b/api/endpoints/wmts.py
@@ -162,6 +162,10 @@ def get_mosaic_tilejson(urls_query_string=''):
     r = requests.get(mosaic_tilejson_url)
     return r.json()
 
+def get_stats(url, bbox):
+    stats_url = settings.TILER_ENDPOINT + '/bbox?url=' + url + '&bbox=' + bbox
+    r = requests.get(stats_url)
+    return r.json()
 
 @ns.route('/GetCapabilities')
 class GetCapabilities(Resource):
@@ -169,6 +173,16 @@ class GetCapabilities(Resource):
     def generate_layer_info(self, key, urls_query_string, collection={}):
         meta = get_mosaic_tilejson(urls_query_string)
         bbox = meta['bounds']
+        stats = None
+        rescale = '-1,1'
+        if len(urls_query_string.split(',')) == 1:
+            stats_resp = get_stats(urls_query_string, ','.join(map(str, bbox)))
+            stats = stats_resp['statistics']['1']
+            std = stats['std']
+            min_scale = stats['min'] - (2*std)
+            max_scale = stats['min'] + (2*std)
+            rescale = ','.join([str(min_scale), str(max_scale)])
+
         layer_info = {
             'layer_title': key,
             'bounds': [ bbox[0], bbox[1], bbox[2], bbox[3] ],
@@ -178,7 +192,7 @@ class GetCapabilities(Resource):
             # TODO(aimee): add settings to wmts_collectionss file
             # TODO(aimee): use defaults from /mosaic/tilejson.json
             'color_map': 'schwarzwald',
-            'rescale': '0,70'
+            'rescale': rescale
         }
         if collection:
             layer_info['query'] = 'short_name=' + collection['short_name'] + '&version=' + collection['version']
@@ -195,8 +209,11 @@ class GetCapabilities(Resource):
         # results from different collections should probably be grouped
         # into different layers (can do this with indexes)
         if len(request_args) > 0:
+            layer_title = 'search_results'
+            if 'granule_ur' in request_args:
+                layer_title = request_args['granule_ur'].replace(':', '')
             urls = get_cog_urls_string(request_args)
-            layers.append(self.generate_layer_info('search_results', urls))
+            layers.append(self.generate_layer_info(layer_title, urls))
         else:
             for key, collection in default_collections.items():
                 browse_urls_query_string = get_cog_urls_string(collection_params(collection))


### PR DESCRIPTION
### Description
This PR modifies the WMS endpoint to assumes the `LAYERS` parameter is the granule ur for loading a WMS layer for a single granule. A `GetCapabilities` XML document for that granule is generated on the fly. Note this also required a change (improvement, now uses the granule ur instead of just the static string) to how layers were being titled and identified in the `GetCapabilities` function.

It also modifies the rescale parameter to use the bbox API endpoint of the maap-tiler api. Using the min and min + 3 std deviations work well for scaling the color map for these 2 collections.

### Testing
Tested by running the api locally (using docker file) and running open layers with layers identified by granule urs, e.g.

```javascript
        'LAYERS': 'SC:AFLVIS2.001:138348873', // or
        'LAYERS': 'uavsar_AfriSAR_v1_SLC-lopenp_14043_16015_001_160308_L090.vrt',
```