### PR TITLE
Use pct clip for rescale

### DIFF
--- a/api/endpoints/wmts.py
+++ b/api/endpoints/wmts.py
@@ -177,11 +177,9 @@ class GetCapabilities(Resource):
         rescale = '-1,1'
         if len(urls_query_string.split(',')) == 1:
             stats_resp = get_stats(urls_query_string, ','.join(map(str, bbox)))
+            print(f"response is {stats_resp}")
             stats = stats_resp['statistics']['1']
-            std = stats['std']
-            min_scale = stats['min']
-            max_scale = stats['min'] + (3*std)
-            rescale = ','.join([str(min_scale), str(max_scale)])
+            rescale = ','.join([str(stats['pc'][0]), str(stats['pc'][1])])
 
         layer_info = {
             'layer_title': key,

--- a/api/endpoints/wmts.py
+++ b/api/endpoints/wmts.py
@@ -177,7 +177,6 @@ class GetCapabilities(Resource):
         rescale = '-1,1'
         if len(urls_query_string.split(',')) == 1:
             stats_resp = get_stats(urls_query_string, ','.join(map(str, bbox)))
-            print(f"response is {stats_resp}")
             stats = stats_resp['statistics']['1']
             rescale = ','.join([str(stats['pc'][0]), str(stats['pc'][1])])
 

--- a/test/api/endpoints/test_wmts_get_capabilities.py
+++ b/test/api/endpoints/test_wmts_get_capabilities.py
@@ -29,7 +29,14 @@ class GetCapabilitiesCase(unittest.TestCase):
                                                      'tilejson': '2.1.0',
                                                      'tiles': ['https://888.execute-api.us-east-1.amazonaws.com/production/mosaic/{z}/{x}/{y}.png?urls=s3://bucket/cog.tif']
                                                  })
-            wmts.get_cog_urls_string = MagicMock(return_value = 'test.tif')
+            wmts.get_stats = MagicMock(return_value = {
+                                         'statistics': {
+                                           '1': {
+                                             'pc': [2.3, 51.1]
+                                           }
+                                         }
+                                       })
+            wmts.get_cog_urls_string = MagicMock(return_value = 'out.cog.tif')
 
     def test_get_capabilities_default(self):
         response = self.app.get(self.get_capabilities_path())


### PR DESCRIPTION
The tiler api returns a percent clip of 2% to 98% which works better as a default for rescaling the color map than the min / max being used before.

Testing:
* Ran the docker image locally and verified /GetCapabilities returns updated endpoint