### PR TITLE
Ab/update bucket

### DIFF
--- a/api/endpoints/wmts.py
+++ b/api/endpoints/wmts.py
@@ -186,7 +186,7 @@ class GetCapabilities(Resource):
         if len(urls_query_string.split(',')) == 1:
             stats_resp = get_stats(urls_query_string, ','.join(map(str, bbox)))
             stats = stats_resp['statistics']['1']
-            rescale = ','.join([str(stats['percentiles'][0]), str(stats['percentiles'][1])])
+            rescale = ','.join([str(stats['pc'][0]), str(stats['pc'][1])])
 
         layer_info = {
             'layer_title': key,

--- a/api/endpoints/wmts_collections.py
+++ b/api/endpoints/wmts_collections.py
@@ -10,6 +10,6 @@ default_collections = {
     "version": "2.0.1",
     "rescale": "0,70",
     "color_map": "schwarzwald",
-    "mosaiced_cog": "s3://cumulus-map-internal/file-staging/nasa-map/lvis_collection_level_2___2.0.1/lvis2-mosaic_cog.tif"
+    "mosaiced_cog": "s3://nasa-maap-data-store/file-staging/nasa-map/lvis_collection_level_2___2.0.1/lvis2-mosaic_cog.tif"
   }
 }

--- a/api/settings.py
+++ b/api/settings.py
@@ -1,6 +1,7 @@
 MAAP_API_URL = "https://api.maap.xyz/api"
 PROJECT_QUEUE_PREFIX = "maap"
 API_HOST_URL = 'http://0.0.0.0:5000/'
+# API_HOST_URL = 'https://api.maap-project.org/api'
 
 # Flask settings
 FLASK_SERVER_NAME = 'localhost:5000'
@@ -51,7 +52,7 @@ GRQ_REST_URL = 'http://[GRQ_IP]/api/v0.1'
 S3_CODE_BUCKET = 's3://[S3_BUCKET_NAME]'
 
 # FASTBROWSE API
-TILER_ENDPOINT = 'https://d852m4cmf5.execute-api.us-east-1.amazonaws.com'
+TILER_ENDPOINT = 'https://8e9mu91qr6.execute-api.us-east-1.amazonaws.com/production'
 
 # 3D Tiles API
 DATA_SYSTEM_SERVICES_API_BASE = 'https://llxbmdibvf.execute-api.us-east-1.amazonaws.com/test'

--- a/api/settings.py
+++ b/api/settings.py
@@ -51,8 +51,15 @@ HYSDS_LW_VERSION = 'v0.0.5'
 GRQ_REST_URL = 'http://[GRQ_IP]/api/v0.1'
 S3_CODE_BUCKET = 's3://[S3_BUCKET_NAME]'
 
-# FASTBROWSE API
-TILER_ENDPOINT = 'https://8e9mu91qr6.execute-api.us-east-1.amazonaws.com/production'
+# Dynamic Tiler API - OLD API
+#
+# Uncomment the `TILER_ENDPOINT` line below if testing api.maap-project.org at this time.
+# api.maap-project.org is using an older version of the Dynamic Tiler API.
+# TILER_ENDPOINT = 'https://8e9mu91qr6.execute-api.us-east-1.amazonaws.com/production'
+
+# Dynamic Tiler API - NEW API
+# The updated WMTS code (api/endpoints/wmts.py) should work with the newer version of the tiler API is deployed at the URL below.
+TILER_ENDPOINT = 'https://d852m4cmf5.execute-api.us-east-1.amazonaws.com'
 
 # 3D Tiles API
 DATA_SYSTEM_SERVICES_API_BASE = 'https://llxbmdibvf.execute-api.us-east-1.amazonaws.com/test'

--- a/test/api/endpoints/test_wmts_get_tile_new_titiler.py
+++ b/test/api/endpoints/test_wmts_get_tile_new_titiler.py
@@ -11,7 +11,7 @@ import pdb
 
 g1 = {
     'granule_ur': 'uavsar_AfriSAR_v1_SLC-lopenp_14043_16015_001_160308_L090.vrt',
-    'cog_url': 's3://cumulus-map-internal/file-staging/circleci/AfriSAR_UAVSAR_Coreg_SLC___1/uavsar_AfriSAR_v1_SLC-lopenp_14043_16015_001_160308_L090.vrt.cog.tif',
+    'cog_url': 's3://nasa-maap-data-store/file-staging/circleci/AfriSAR_UAVSAR_Coreg_SLC___1/uavsar_AfriSAR_v1_SLC-lopenp_14043_16015_001_160308_L090.vrt.cog.tif',
     'color_map': 'schwarzwald',
     'rescale': '-1,1',
     'zxy': '10/545/513'
@@ -19,19 +19,19 @@ g1 = {
 
 g2 = {
     'granule_ur': 'uavsar_AfriSAR_v1_SLC-hundre_14048_16008_007_160225_L090.vrt',
-    'cog_url': 's3://cumulus-map-internal/file-staging/circleci/AfriSAR_UAVSAR_Coreg_SLC___1/uavsar_AfriSAR_v1_SLC-hundre_14048_16008_007_160225_L090.vrt.cog.tif'
+    'cog_url': 's3://nasa-maap-data-store/file-staging/circleci/AfriSAR_UAVSAR_Coreg_SLC___1/uavsar_AfriSAR_v1_SLC-hundre_14048_16008_007_160225_L090.vrt.cog.tif'
 }
 
 g3 = {    
     'granule_ur': 'SC:AFLVIS2.001:138349020',
-    'cog_url': 's3://cumulus-map-internal/file-staging/nasa-map/AFLVIS2___001/LVIS2_Gabon2016_0308_R1808_048492_cog.tif',
+    'cog_url': 's3://nasa-maap-data-store/file-staging/nasa-map/AFLVIS2___001/LVIS2_Gabon2016_0308_R1808_048492_cog.tif',
     'rescale':'11,57',
     'zxy': '11/1077/1020',
     'indexes':'1,2'
 }
 g4 = {
     'granule_ur': 'SC:AFLVIS2.001:138348905',
-    'cog_url': 's3://cumulus-map-internal/file-staging/nasa-map/AFLVIS2___001/LVIS2_Gabon2016_0308_R1808_049095_cog.tif',
+    'cog_url': 's3://nasa-maap-data-store/file-staging/nasa-map/AFLVIS2___001/LVIS2_Gabon2016_0308_R1808_049095_cog.tif',
     'rescale':'11,57',
     'zxy': '11/1077/1020',
     'indexes':'1,2'


### PR DESCRIPTION
- api.maap-project.org is still using the older version of the tiler so updated settings.py to reflect that
- updated the bucket to nasa-maap-data-store for the LVIS mosaicked cog
- updated tests for the new tiler which point to nasa-maap-data-store
