### PR TITLE
Ignore granule's missing Content-Type header.

### DIFF
--- a/api/endpoints/cmr.py
+++ b/api/endpoints/cmr.py
@@ -149,7 +149,7 @@ class CmrGranuleData(Resource):
 
         return Response(
             response=stream_with_context(response.iter_content(chunk_size=1024 * 10)),
-            content_type=response.headers["Content-Type"],
+            content_type=(response.headers['Content-Type'] if 'Content-Type' in response.headers else None),
             direct_passthrough=True)
 
 

--- a/api/endpoints/cmr.py
+++ b/api/endpoints/cmr.py
@@ -149,7 +149,7 @@ class CmrGranuleData(Resource):
 
         return Response(
             response=stream_with_context(response.iter_content(chunk_size=1024 * 10)),
-            content_type=(response.headers['Content-Type'] if 'Content-Type' in response.headers else None),
+            content_type=response.headers.get('Content-Type'),
             direct_passthrough=True)
 
 


### PR DESCRIPTION
This PR fixes MAAP API errors when downloading certain granules. 

Some hosted services omit a 'Content-Type' header in the granule get response, which was throwing a missing key error within the MAAP API. This fix handles this case by forwarding the missing header as-is to the client. 

Additional info: https://github.com/MAAP-Project/ZenHub/issues/676