### PR TITLE
Expose proxied url within API endpoints

### DIFF
--- a/api/cas/cas_auth.py
+++ b/api/cas/cas_auth.py
@@ -18,6 +18,7 @@ from Crypto.Cipher import PKCS1_v1_5
 from Crypto import Random
 from Crypto.Hash import SHA
 from base64 import b64decode
+from api.utils.url_util import proxied_url
 import ast
 
 
@@ -51,7 +52,7 @@ def validate_proxy(ticket):
     else:
         cas_validate_proxy_url = create_cas_proxy_url(
             current_app.config['CAS_SERVER'],
-            request.base_url,
+            proxied_url(request),
             decrypted_ticket
         )
 
@@ -65,7 +66,7 @@ def validate_proxy(ticket):
 
             proxy_validate_url = create_cas_proxy_validate_url(
                 current_app.config['CAS_SERVER'],
-                request.base_url,
+                proxied_url(request),
                 proxy_ticket
             )
 

--- a/api/endpoints/members.py
+++ b/api/endpoints/members.py
@@ -19,6 +19,7 @@ import json
 import boto3
 import requests
 from urllib import parse
+from api.utils.url_util import proxied_url
 
 
 log = logging.getLogger(__name__)
@@ -149,11 +150,11 @@ class Member(Resource):
 
         # Send Email Notifications based on member status
         if status == STATUS_ACTIVE:
-            send_user_status_change_email(guest, True, True, request.base_url)
-            send_welcome_to_maap_active_user_email(guest, request.base_url)
+            send_user_status_change_email(guest, True, True, proxied_url(request))
+            send_welcome_to_maap_active_user_email(guest, proxied_url(request))
         else:
-            send_user_status_change_email(guest, True, False, request.base_url)
-            send_welcome_to_maap_suspended_user_email(guest, request.base_url)
+            send_user_status_change_email(guest, True, False, proxied_url(request))
+            send_welcome_to_maap_suspended_user_email(guest, proxied_url(request))
 
         member_schema = MemberSchema()
         return json.loads(member_schema.dumps(guest))
@@ -276,13 +277,13 @@ class MemberStatus(Resource):
 
         # Send "Account Activated" email notification to Member & Admins
         if activated:
-            send_user_status_update_active_user_email(member, request.base_url)
-            send_user_status_change_email(member, False, True, request.base_url)
+            send_user_status_update_active_user_email(member, proxied_url(request))
+            send_user_status_change_email(member, False, True, proxied_url(request))
 
         # Send "Account Deactivated" email notification to Member & Admins
         if deactivated:
-            send_user_status_update_suspended_user_email(member, request.base_url)
-            send_user_status_change_email(member, False, False, request.base_url)
+            send_user_status_update_suspended_user_email(member, proxied_url(request))
+            send_user_status_change_email(member, False, False, proxied_url(request))
 
         member_schema = MemberSchema()
         return json.loads(member_schema.dumps(member))

--- a/api/utils/url_util.py
+++ b/api/utils/url_util.py
@@ -1,0 +1,2 @@
+def proxied_url(request):
+    return "https://{}{}".format(request.environ['HTTP_X_FORWARDED_HOST'], request.full_path)


### PR DESCRIPTION
Updated references to `request.base_url` to account for docker container proxy.