### PR TITLE
Update maap_database.py

### DIFF
--- a/api/maap_database.py
+++ b/api/maap_database.py
@@ -1,3 +1,3 @@
 from flask_sqlalchemy import SQLAlchemy
 
-db = SQLAlchemy()
+db = SQLAlchemy(session_options={'autocommit': True})


### PR DESCRIPTION
This change fixes the `sqlalchemy.exc.TimeoutError` exceptions occurring in tag 3.0.1