### PR TITLE
Bugs/sql alchemy auto commit

### DIFF
--- a/api/maap_database.py
+++ b/api/maap_database.py
@@ -1,3 +1,3 @@
 from flask_sqlalchemy import SQLAlchemy
 
-db = SQLAlchemy(session_options={'autocommit': True})
+db = SQLAlchemy()

--- a/api/maapapp.py
+++ b/api/maapapp.py
@@ -38,6 +38,7 @@ app.config['CAS_AFTER_LOGIN'] = settings.CAS_AFTER_LOGIN
 app.config['CAS_USERNAME_SESSION_KEY'] = 'cas_token_session_key'
 app.config['SQLALCHEMY_DATABASE_URI'] = settings.DATABASE_URL
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+app.config['SQLALCHEMY_ENGINE_OPTIONS'] = {'isolation_level': 'AUTOCOMMIT'}
 
 app.app_context().push()
 db.init_app(app)


### PR DESCRIPTION
This fix resolves the API runtime error "sqlalchemy.exc.ArgumentError: autocommit=True is no longer supported"