### PR TITLE
Double tag bug

### DIFF
--- a/api/utils/hysds_util.py
+++ b/api/utils/hysds_util.py
@@ -42,6 +42,7 @@ def remove_double_tag(mozart_response):
     except: 
         # Okay if you just cannot access tags, don't need to remove duplicates in this case 
         pass
+    return mozart_response
 
 def get_es_query_by_job_id(job_id):
     """

--- a/api/utils/hysds_util.py
+++ b/api/utils/hysds_util.py
@@ -37,7 +37,7 @@ def remove_double_tag(mozart_response):
         tags = mozart_response["result"]["tags"]
         logging.info(tags)
         if isinstance(tags, list):
-            tags = set(tags)
+            tags = list(set(tags))
             mozart_response["result"]["tags"] = tags
     except: 
         # Okay if you just cannot access tags, don't need to remove duplicates in this case 

--- a/api/utils/hysds_util.py
+++ b/api/utils/hysds_util.py
@@ -24,7 +24,12 @@ def get_mozart_job_info(job_id):
     session = requests.Session()
     session.verify = False
     mozart_response = session.get("{}/job/info".format(settings.MOZART_URL), params=params).json()
+    remove_double_tag(mozart_response)
     return mozart_response
+
+def remove_double_tag(mozart_response):
+    logging.info("graceal1 in remove_double_tag with ")
+    logging.info(mozart_response)
 
 def get_es_query_by_job_id(job_id):
     """

--- a/api/utils/hysds_util.py
+++ b/api/utils/hysds_util.py
@@ -33,9 +33,7 @@ def remove_double_tag(mozart_response):
     :return: updated mozart_response with duplicate tags removed 
     """
     try:
-        logging.info("graceal1 in remove_double_tag with ")
         tags = mozart_response["result"]["tags"]
-        logging.info(tags)
         if isinstance(tags, list):
             tags = list(set(tags))
             mozart_response["result"]["tags"] = tags
@@ -395,16 +393,12 @@ def mozart_submit_job(job_type, params={}, queue=settings.DEFAULT_QUEUE, dedup="
     job_payload["type"] = job_type
     job_payload["queue"] = queue
     job_payload["priority"] = 0
-    logging.info("graceal1 in mozart_submit_job")
     tags_list = ["maap-api-submit"]
     if identifier is not None:
         if type(identifier) is list:
             tags_list = identifier
         elif type(identifier) is str:
             tags_list = str(identifier).split(",")
-    logging.info("graceal1 tags_list is ")
-    logging.info(tags_list)
-    logging.info(json.dumps(tags_list))
     job_payload["tags"] = json.dumps(tags_list)
 
     # assign username to job
@@ -422,8 +416,6 @@ def mozart_submit_job(job_type, params={}, queue=settings.DEFAULT_QUEUE, dedup="
 
     session = requests.Session()
     session.verify = False
-    logging.info("graceal1 trying to submit job like ")
-    logging.info(job_payload)
 
     try:
         mozart_response = session.post("{}/job/submit".format(settings.MOZART_URL),

--- a/api/utils/hysds_util.py
+++ b/api/utils/hysds_util.py
@@ -377,12 +377,16 @@ def mozart_submit_job(job_type, params={}, queue=settings.DEFAULT_QUEUE, dedup="
     job_payload["type"] = job_type
     job_payload["queue"] = queue
     job_payload["priority"] = 0
+    logging.info("graceal1 in mozart_submit_job")
     tags_list = ["maap-api-submit"]
     if identifier is not None:
         if type(identifier) is list:
             tags_list = identifier
         elif type(identifier) is str:
             tags_list = str(identifier).split(",")
+    logging.info("graceal1 tags_list is ")
+    logging.info(tags_list)
+    logging.info(json.dumps(tags_list))
     job_payload["tags"] = json.dumps(tags_list)
 
     # assign username to job
@@ -400,6 +404,8 @@ def mozart_submit_job(job_type, params={}, queue=settings.DEFAULT_QUEUE, dedup="
 
     session = requests.Session()
     session.verify = False
+    logging.info("graceal1 trying to submit job like ")
+    logging.info(job_payload)
 
     try:
         mozart_response = session.post("{}/job/submit".format(settings.MOZART_URL),

--- a/api/utils/hysds_util.py
+++ b/api/utils/hysds_util.py
@@ -24,12 +24,24 @@ def get_mozart_job_info(job_id):
     session = requests.Session()
     session.verify = False
     mozart_response = session.get("{}/job/info".format(settings.MOZART_URL), params=params).json()
-    remove_double_tag(mozart_response)
-    return mozart_response
+    return remove_double_tag(mozart_response)
 
 def remove_double_tag(mozart_response):
-    logging.info("graceal1 in remove_double_tag with ")
-    logging.info(mozart_response)
+    """
+    Remove duplicates from the tags field 
+    :param mozart_response:
+    :return: updated mozart_response with duplicate tags removed 
+    """
+    try:
+        logging.info("graceal1 in remove_double_tag with ")
+        tags = mozart_response["result"]["tags"]
+        logging.info(tags)
+        if isinstance(tags, list):
+            tags = set(tags)
+            mozart_response["result"]["tags"] = tags
+    except: 
+        # Okay if you just cannot access tags, don't need to remove duplicates in this case 
+        pass
 
 def get_es_query_by_job_id(job_id):
     """


### PR DESCRIPTION
Remove duplicates from the job tags, we wanted to have this done on the hysds side, but it seemed it would be too complicated/ time consuming 
Before:
<img width="1088" alt="Screenshot 2024-01-24 at 8 58 08 AM" src="https://github.com/MAAP-Project/maap-api-nasa/assets/114033465/432706b3-7ffe-4304-a39d-17bbd0481c8d">

After:
<img width="1074" alt="Screenshot 2024-01-24 at 8 54 32 AM" src="https://github.com/MAAP-Project/maap-api-nasa/assets/114033465/ca220122-a20e-432f-9847-c0f6b62c07bf">
