### PR TITLE
Bug: update returned ssh key info

### DIFF
--- a/api/endpoints/members.py
+++ b/api/endpoints/members.py
@@ -342,6 +342,8 @@ class Self(Resource):
             Member_db.email,
             Member_db.status,
             Member_db.public_ssh_key,
+            Member_db.public_ssh_key_name,
+            Member_db.public_ssh_key_modified_date,
             Member_db.creation_date
         ]
 

--- a/api/endpoints/members.py
+++ b/api/endpoints/members.py
@@ -103,6 +103,26 @@ class Member(Resource):
             pgt_result = json.loads(member_session_schema.dumps(pgt_ticket))
             result = json.loads(json.dumps(dict(result.items() | pgt_result.items())))
 
+        # If the requested user info belongs to the logged in user,
+        # also include additional ssh key information belonging to the user
+        authorized_user = get_authorized_user()
+        if authorized_user.username == key:
+
+            cols = [
+                Member_db.id,
+                Member_db.public_ssh_key_name,
+                Member_db.public_ssh_key_modified_date
+            ]
+
+            member = db.session \
+                .query(Member_db) \
+                .with_entities(*cols) \
+                .filter_by(username=key) \
+                .first()
+            
+            member_schema = MemberSchema()
+            result = json.loads(member_schema.dumps(member))
+
         return result
 
     @api.doc(security='ApiKeyAuth')

--- a/api/endpoints/members.py
+++ b/api/endpoints/members.py
@@ -119,7 +119,7 @@ class Member(Resource):
                 .with_entities(*cols) \
                 .filter_by(username=key) \
                 .first()
-            
+
             member_schema = MemberSchema()
             result = json.loads(member_schema.dumps(member))
 

--- a/api/endpoints/members.py
+++ b/api/endpoints/members.py
@@ -117,7 +117,7 @@ class Member(Resource):
             member = db.session \
                 .query(Member_db) \
                 .with_entities(*cols) \
-                .filter_by(username=key) \
+                .filter_by(username=authorized_user.username) \
                 .first()
 
             member_schema = MemberSchema()

--- a/api/endpoints/members.py
+++ b/api/endpoints/members.py
@@ -109,7 +109,6 @@ class Member(Resource):
         if authorized_user.username == key:
 
             cols = [
-                Member_db.id,
                 Member_db.public_ssh_key_name,
                 Member_db.public_ssh_key_modified_date
             ]


### PR DESCRIPTION
We were missing SSH info needed by the portal. This PR addresses this bug.

Changed:
* When calling the `members/:key` endpoint, if the user information being requested belongs to the logged in user that is making the request, we now return the `public_ssh_key_name` and `public_ssh_key_modified_date` fields.
* When calling the `members/self` endpoint, we now return the `public_ssh_key_name` and `public_ssh_key_modified_date` fields.