### PR TITLE
Fix triaged-jobs s3fs mapping

### DIFF
--- a/api/endpoints/members.py
+++ b/api/endpoints/members.py
@@ -472,6 +472,8 @@ class PresignedUrlS3(Resource):
             return key.replace(settings.WORKSPACE_MOUNT_PUBLIC, f'{settings.AWS_SHARED_WORKSPACE_BUCKET_PATH}/{ws}')
         elif key.startswith(settings.WORKSPACE_MOUNT_SHARED):
             return key.replace(settings.WORKSPACE_MOUNT_SHARED, settings.AWS_SHARED_WORKSPACE_BUCKET_PATH)
+        elif key.startswith(settings.WORKSPACE_MOUNT_TRIAGE):
+            return key.replace(settings.WORKSPACE_MOUNT_TRIAGE, settings.AWS_TRIAGE_WORKSPACE_BUCKET_PATH)
         else:
             return key
 

--- a/api/settings.py
+++ b/api/settings.py
@@ -1,4 +1,4 @@
-MAAP_API_URL = "https://api.dit.maap-project.org/api"
+MAAP_API_URL = "http://localhost:5000/api"
 PROJECT_QUEUE_PREFIX = "maap"
 API_HOST_URL = 'http://0.0.0.0:5000/'
 
@@ -84,7 +84,9 @@ WORKSPACE_BUCKET_ARN = ''
 WORKSPACE_MOUNT_PRIVATE = 'my-private-bucket'
 WORKSPACE_MOUNT_PUBLIC = 'my-public-bucket'
 WORKSPACE_MOUNT_SHARED = 'shared-buckets'
+WORKSPACE_MOUNT_TRIAGE = 'triaged-jobs'
 AWS_SHARED_WORKSPACE_BUCKET_PATH = 'shared'
+AWS_TRIAGE_WORKSPACE_BUCKET_PATH = 'dataset/triaged_job'
 AWS_REQUESTER_PAYS_BUCKET_ARN = 'arn:aws:iam::???:role/???'
 
 # DB


### PR DESCRIPTION
Add a new mapping to the triaged jobs s3 folder to allow for file path copying from the ADE `triaged-jobs` mounted directory. For more info see: https://github.com/MAAP-Project/Community/issues/932