### PR TITLE
remove outdated CMR, WMS, WMTS endpoints from app

### DIFF
--- a/api/maapapp.py
+++ b/api/maapapp.py
@@ -8,11 +8,8 @@ from api import settings
 from api.cas.cas_auth import validate
 from api.utils.environments import Environments, get_environment
 from api.utils.url_util import proxied_url
-from api.endpoints.cmr import ns as cmr_collections_namespace
 from api.endpoints.algorithm import ns as algorithm_namespace
 from api.endpoints.job import ns as job_namespace
-from api.endpoints.wmts import ns as wmts_namespace
-from api.endpoints.wms import ns as wms_namespace
 from api.endpoints.members import ns as members_namespace
 from api.endpoints.environment import ns as environment_namespace
 from api.restplus import api
@@ -29,7 +26,6 @@ log = logging.getLogger(__name__)
 
 blueprint = Blueprint('baseapi', __name__, url_prefix='/api')
 api.init_app(blueprint)
-api.add_namespace(cmr_collections_namespace)
 app.register_blueprint(blueprint)
 
 app.config['CAS_SERVER'] = settings.CAS_SERVER_NAME
@@ -95,11 +91,8 @@ def initialize_app(flask_app):
 
     blueprint = Blueprint('api', __name__, url_prefix='/api')
     api.init_app(blueprint)
-    api.add_namespace(cmr_collections_namespace)
     api.add_namespace(algorithm_namespace)
     api.add_namespace(job_namespace)
-    api.add_namespace(wmts_namespace)
-    api.add_namespace(wms_namespace)
     api.add_namespace(members_namespace)
     api.add_namespace(environment_namespace)
     flask_app.register_blueprint(blueprint)


### PR DESCRIPTION
This PR removes outdated endpoints from the app : 
- CMR
- WMS
- WMTS

However, the task of removing all the internal, non-user facing logic related to these endpoints (e.g. `api/endpoints/cmr.py`, `api/endpoints/wms.py`, etc...) is left for the future. 

I don't have a way to run and test this locally so I am minimizing the changes. 