### PR TITLE
Add local docker-compose to bypass gunicorn

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Development server: https://api.dit.maap-project.org/api
 
 ```bash
 cd docker
-docker-compose up
+docker-compose -f docker-compose-local.yml up
 ```
 
 ## II. Local development using python virtualenv

--- a/docker/docker-compose-local.yml
+++ b/docker/docker-compose-local.yml
@@ -1,0 +1,47 @@
+version: '3.8'
+services:
+  api:
+    container_name: 'maap-api-nasa'
+    image: 'maap-api-nasa'
+    build:
+      context: ../
+      dockerfile: docker/Dockerfile
+    depends_on:
+      db:
+        condition: service_healthy
+    networks:
+      - default
+    ports:
+      - "5000:5000"
+    volumes:
+      - ./logs:/maap-api-nasa/logs/
+    command: >
+      sh -c "flask run --host=0.0.0.0"
+    environment:
+      FLASK_APP: /maap-api-nasa/api/maapapp.py
+    restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: 250m
+        max-file: 10
+
+  db:
+    image: postgres:14.5
+    restart: always
+    environment:
+      POSTGRES_DB: maap
+      POSTGRES_USER: maapuser
+      POSTGRES_PASSWORD: mysecretpassword
+      PGDATA: /var/lib/postgresql/data/pgdata
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./data:/var/lib/postgresql/data
+    networks:
+      - default
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -d postgresql://maapuser:mysecretpassword@db/maap"]
+      interval: 5s
+      timeout: 5s
+      retries: 50


### PR DESCRIPTION
To address startup errors when running locally, add a docker-compose-local.yml file and update docs to use local flask service. gunicorn is required when running in production mode but typically unnecessary when debugging locally.