### PR TITLE
added query params to job list endpoint

### DIFF
--- a/api/endpoints/job.py
+++ b/api/endpoints/job.py
@@ -455,10 +455,17 @@ class Metrics(Resource):
 @ns.route('/job/<string:username>/list')
 class Jobs(Resource):
     parser = api.parser()
-    parser.add_argument('page_size', required=False, type=str,
-                        help="Job Listing Pagination Size")
-    parser.add_argument('offset', required=False, type=str,
-                        help="Job Listing Pagination Offset")
+    parser.add_argument('page_size', required=False, type=str, help="Job Listing Pagination Size")
+    parser.add_argument('offset', required=False, type=str, help="Job Listing Pagination Offset")
+    parser.add_argument('type', type=str, help="Job type + version (ie. topsapp:v1.0)", required=False)
+    parser.add_argument('tag', type=str, help="User-defined job tag", required=False)
+    parser.add_argument('queue', type=str, help="Submitted job queue", required=False)
+    parser.add_argument('priority', type=int, help="Job priority, 0-9", required=False)
+    parser.add_argument('start_time', type=str, help="Start time of @timestamp field", required=False)
+    parser.add_argument('end_time', type=str, help="Start time of @timestamp field", required=False)
+    parser.add_argument('get_job_details', type=bool, help="Return full details if True. List of job id's if false. Default True.", required=False)
+    parser.add_argument('status', type=str, help="Job status, ie. job-queued, job-started, job-completed, "
+                                                 "job-failed", required=False)
 
 
     @api.doc(security='ApiKeyAuth')

--- a/api/endpoints/job.py
+++ b/api/endpoints/job.py
@@ -504,15 +504,16 @@ class Jobs(Resource):
         
         # Get params and set default values
         params = {key: request.args.get(key, default) for key, default in defaults.items()}
-
-        # Filter out params that are not needed for the mozart request
-        filtered_query_params = {k: v for k, v in params.items() if k != 'get_job_details' and v is not None}
+        
+        # Filter out params that are not needed
+        exclude_list = ["username", "get_job_details"]
+        filtered_query_params = {k: v for k, v in params.items() if k not in exclude_list and v is not None}
 
         try:
             logging.info("Finding jobs for user: {}".format(username))
             
             # Get list of jobs ids for the user
-            response = hysds.get_mozart_jobs(**filtered_query_params)
+            response = hysds.get_mozart_jobs(username, filtered_query_params)
             job_list = response.get("result")
             logging.info("Found Jobs: {}".format(job_list))
             

--- a/api/endpoints/job.py
+++ b/api/endpoints/job.py
@@ -513,7 +513,7 @@ class Jobs(Resource):
             logging.info("Finding jobs for user: {}".format(username))
             logging.info("test")
             # Get list of jobs ids for the user
-            response = hysds.get_mozart_jobs(username, filtered_query_params)
+            response = hysds.get_mozart_jobs(username, **filtered_query_params)
             job_list = response.get("result")
             logging.info("Found Jobs: {}".format(job_list))
             

--- a/api/endpoints/job.py
+++ b/api/endpoints/job.py
@@ -499,7 +499,7 @@ class Jobs(Resource):
             "priority" : None,
             "queue" : None,
             "tag" : None,
-            "type" : None
+            "job_type" : None
         }
         
         # Get params and set default values

--- a/api/endpoints/job.py
+++ b/api/endpoints/job.py
@@ -457,7 +457,7 @@ class Jobs(Resource):
     parser = api.parser()
     parser.add_argument('page_size', required=False, type=str, help="Job Listing Pagination Size")
     parser.add_argument('offset', required=False, type=str, help="Job Listing Pagination Offset")
-    parser.add_argument('type', type=str, help="Job type + version (ie. topsapp:v1.0)", required=False)
+    parser.add_argument('job_type', type=str, help="Job type + version (ie. topsapp:v1.0)", required=False)
     parser.add_argument('tag', type=str, help="User-defined job tag", required=False)
     parser.add_argument('queue', type=str, help="Submitted job queue", required=False)
     parser.add_argument('priority', type=int, help="Job priority, 0-9", required=False)
@@ -484,7 +484,7 @@ class Jobs(Resource):
         :param priority: Job priority
         :param queue: Queue
         :param tag: User tag
-        :param type: Algorithm type
+        :param job_type: Algorithm type
         :return: List of jobs for a given user that matches query params provided
         """
         
@@ -514,7 +514,6 @@ class Jobs(Resource):
             logging.info("Finding jobs for user: {}".format(username))
             # Get list of jobs ids for the user
             response = hysds.get_mozart_jobs(username, **filtered_query_params)
-            print(response)
             job_list = response.get("result")
             logging.info("Found Jobs: {}".format(job_list))
             

--- a/api/endpoints/job.py
+++ b/api/endpoints/job.py
@@ -504,6 +504,7 @@ class Jobs(Resource):
         
         # Get params and set default values
         params = {key: request.args.get(key, default) for key, default in defaults.items()}
+        get_job_details = bool(params.get("get_job_details"))
         
         # Filter out params that are not needed
         exclude_list = ["username", "get_job_details"]
@@ -511,7 +512,6 @@ class Jobs(Resource):
 
         try:
             logging.info("Finding jobs for user: {}".format(username))
-            logging.info("test")
             # Get list of jobs ids for the user
             response = hysds.get_mozart_jobs(username, **filtered_query_params)
             job_list = response.get("result")

--- a/api/endpoints/job.py
+++ b/api/endpoints/job.py
@@ -457,15 +457,14 @@ class Jobs(Resource):
     parser = api.parser()
     parser.add_argument('page_size', required=False, type=str, help="Job Listing Pagination Size")
     parser.add_argument('offset', required=False, type=str, help="Job Listing Pagination Offset")
-    parser.add_argument('job_type', type=str, help="Job type + version (ie. topsapp:v1.0)", required=False)
+    parser.add_argument('job_type', type=str, help="Job type + version, e.g. topsapp:v1.0", required=False)
     parser.add_argument('tag', type=str, help="User-defined job tag", required=False)
     parser.add_argument('queue', type=str, help="Submitted job queue", required=False)
     parser.add_argument('priority', type=int, help="Job priority, 0-9", required=False)
     parser.add_argument('start_time', type=str, help="Start time of @timestamp field", required=False)
     parser.add_argument('end_time', type=str, help="Start time of @timestamp field", required=False)
     parser.add_argument('get_job_details', type=bool, help="Return full details if True. List of job id's if false. Default True.", required=False)
-    parser.add_argument('status', type=str, help="Job status, ie. job-queued, job-started, job-completed, "
-                                                 "job-failed", required=False)
+    parser.add_argument('status', type=str, help="Job status, e.g. Accepted, Running, Succeeded, Failed, etc.", required=False)
 
 
     @api.doc(security='ApiKeyAuth')
@@ -491,8 +490,8 @@ class Jobs(Resource):
         defaults = {
             "username" : username,
             "get_job_details" : True, # To preserve existing behavior, set default to True. In the future, we should set this to False.
-            "page_size" : None,
-            "offset" : None,
+            "page_size" : 10,
+            "offset" : 0,
             "status" : None,
             "end_time" : None,
             "start_time" : None,
@@ -507,6 +506,10 @@ class Jobs(Resource):
 
         is_param_true = lambda x: x if isinstance(x, bool) else x.lower() == 'true'
         get_job_details = is_param_true(params['get_job_details'])
+
+        # If status is provided, make sure it is HySDS-compliant
+        if params['status'] is not None:
+            params['status'] = ogc.get_hysds_status_from_wps(params['status'])
         
         # Filter out the non-query params for the Mozart request
         exclude_list = ["username", "get_job_details"]

--- a/api/endpoints/job.py
+++ b/api/endpoints/job.py
@@ -511,7 +511,7 @@ class Jobs(Resource):
 
         try:
             logging.info("Finding jobs for user: {}".format(username))
-            
+            logging.info("test")
             # Get list of jobs ids for the user
             response = hysds.get_mozart_jobs(username, filtered_query_params)
             job_list = response.get("result")

--- a/api/endpoints/job.py
+++ b/api/endpoints/job.py
@@ -504,9 +504,9 @@ class Jobs(Resource):
         
         # Get params and set default values
         params = {key: request.args.get(key, default) for key, default in defaults.items()}
-        print(params)
-        get_job_details = bool(params.get("get_job_details"))
-        print(get_job_details)
+
+        is_param_true = lambda x: x if isinstance(x, bool) else x.lower() == 'true'
+        get_job_details = is_param_true(params['get_job_details'])
         
         # Filter out the non-query params for the Mozart request
         exclude_list = ["username", "get_job_details"]

--- a/api/endpoints/job.py
+++ b/api/endpoints/job.py
@@ -506,7 +506,7 @@ class Jobs(Resource):
         params = {key: request.args.get(key, default) for key, default in defaults.items()}
         get_job_details = bool(params.get("get_job_details"))
         
-        # Filter out params that are not needed
+        # Filter out the non-query params for the Mozart request
         exclude_list = ["username", "get_job_details"]
         filtered_query_params = {k: v for k, v in params.items() if k not in exclude_list and v is not None}
 
@@ -514,6 +514,7 @@ class Jobs(Resource):
             logging.info("Finding jobs for user: {}".format(username))
             # Get list of jobs ids for the user
             response = hysds.get_mozart_jobs(username, **filtered_query_params)
+            print(response)
             job_list = response.get("result")
             logging.info("Found Jobs: {}".format(job_list))
             

--- a/api/endpoints/job.py
+++ b/api/endpoints/job.py
@@ -504,7 +504,9 @@ class Jobs(Resource):
         
         # Get params and set default values
         params = {key: request.args.get(key, default) for key, default in defaults.items()}
+        print(params)
         get_job_details = bool(params.get("get_job_details"))
+        print(get_job_details)
         
         # Filter out the non-query params for the Mozart request
         exclude_list = ["username", "get_job_details"]

--- a/api/utils/hysds_util.py
+++ b/api/utils/hysds_util.py
@@ -657,7 +657,6 @@ def get_mozart_jobs(username, **kwargs):
             url = "{}/job/user/{}?{}".format(settings.MOZART_URL, username, param_list[1:])
         logging.info("GET request to find jobs: {}".format(url))
         mozart_response = session.get(url)
-        print(mozart_response.url)
 
     except Exception as ex:
         raise ex

--- a/api/utils/hysds_util.py
+++ b/api/utils/hysds_util.py
@@ -633,7 +633,9 @@ def get_mozart_jobs(username, **kwargs):
         :return:
         """
     params = dict()
+    logging.info("hysds utils")
     for key, value in kwargs.items():
+        logging.info("key: {}, value: {}".format(key, value))
         params[key] = value
 
     session = requests.Session()

--- a/api/utils/hysds_util.py
+++ b/api/utils/hysds_util.py
@@ -671,6 +671,7 @@ def get_mozart_jobs(username,
     logging.debug("Job params: {}".format(params))
 
     try:
+        param_list = ""
         for key, value in params.items():
             param_list += "&{}={}".format(key, value)
 

--- a/api/utils/hysds_util.py
+++ b/api/utils/hysds_util.py
@@ -639,11 +639,14 @@ def get_mozart_jobs(username, **kwargs):
     session = requests.Session()
     session.verify = False
 
+    logging.info("Job params: {}".format(params))
+
     try:
         param_list = ""
         for key, value in params.items():
             param_list += "&{}={}".format(key, value)
 
+        logging.info("Job param list: {}".format(param_list))
         if settings.HYSDS_VERSION == "v3.0":
             if username is not None:
                 param_list += f"&username={username}"

--- a/api/utils/hysds_util.py
+++ b/api/utils/hysds_util.py
@@ -624,7 +624,7 @@ def get_mozart_queues():
         raise Exception("Couldn't get list of available queues")
 
 
-def get_mozart_jobs(username, page_size=10, offset=0):
+def get_mozart_jobs(username, **kwargs):
     """
         Returns mozart's job list
         :param username:
@@ -633,8 +633,8 @@ def get_mozart_jobs(username, page_size=10, offset=0):
         :return:
         """
     params = dict()
-    params["page_size"] = page_size
-    params["offset"] = offset  # this is specifies the offset
+    for key, value in kwargs.items():
+        params[key] = value
 
     session = requests.Session()
     session.verify = False

--- a/api/utils/hysds_util.py
+++ b/api/utils/hysds_util.py
@@ -624,31 +624,56 @@ def get_mozart_queues():
         raise Exception("Couldn't get list of available queues")
 
 
-def get_mozart_jobs(username, **kwargs):
+def get_mozart_jobs(username, 
+                    end_time=None,
+                    job_type=None,
+                    offset=0, 
+                    page_size=10,
+                    priority=None,
+                    queue=None,
+                    start_time=None,
+                    status=None,
+                    tag=None
+                    ):
     """
-        Returns mozart's job list
-        :param username:
-        :param page_size:
-        :param offset:
-        :return:
-        """
-    params = dict()
-    logging.info("hysds utils")
-    for key, value in kwargs.items():
-        logging.info("key: {}, value: {}".format(key, value))
-        params[key] = value
+    Returns mozart's job list
+    :param username: Username
+    :param page_size: Page size for pagination
+    :param offset: Offset for pagination
+    :param status: Job status
+    :param end_time: End time
+    :param start_time: Start time
+    :param priority: Job priority
+    :param queue: Queue
+    :param tag: User tag
+    :param job_type: Algorithm type
+    :return: Job list
+    """
+    params = {
+        k: v
+        for k, v in (
+            ("end_time", end_time),
+            ("job_type", job_type),
+            ("offset", offset),
+            ("page_size", page_size),
+            ("priority", priority),
+            ("queue", queue),
+            ("start_time", start_time),
+            ("status", status),
+            ("tag", tag),
+        )
+        if v is not None
+    }
 
     session = requests.Session()
     session.verify = False
 
-    logging.info("Job params: {}".format(params))
+    logging.debug("Job params: {}".format(params))
 
     try:
-        param_list = ""
         for key, value in params.items():
             param_list += "&{}={}".format(key, value)
 
-        logging.info("Job param list: {}".format(param_list))
         if settings.HYSDS_VERSION == "v3.0":
             if username is not None:
                 param_list += f"&username={username}"

--- a/api/utils/hysds_util.py
+++ b/api/utils/hysds_util.py
@@ -657,6 +657,7 @@ def get_mozart_jobs(username, **kwargs):
             url = "{}/job/user/{}?{}".format(settings.MOZART_URL, username, param_list[1:])
         logging.info("GET request to find jobs: {}".format(url))
         mozart_response = session.get(url)
+        print(mozart_response.url)
 
     except Exception as ex:
         raise ex

--- a/api/utils/ogc_translate.py
+++ b/api/utils/ogc_translate.py
@@ -11,8 +11,8 @@ ns = {
 
 # This list extends the recommended WPS job statuses to include statuses 'Deduped', 'Deleted', and 'Offline'.
 WPS_STATUSES = ["Accepted", "Running", "Succeeded", "Failed", "Dismissed", "Deduped", "Deleted", "Offline"]
-
 HYSDS_STATUSES= ["job-started", "job-completed", "job-queued", "job-failed", "job-deduped", "job-revoked", "job-offline"]
+
 WPS_TO_HYSDS_JOB_STATUS_MAP = {
  "Accepted": "job-queued",
  "Running": "job-started",
@@ -34,35 +34,17 @@ def set_namespaces(xml_element):
 def get_hysds_status_from_wps(wps_status):
     """
     Translate WPS job status to HySDS job status
+
+    NOTE: HySDS does not support job status 'Deleted' and this status is not one of the base WPS job statuses.
+    Treating this status as a pass-through until there is consensus on HySDS-WPS mapping.
+
     :param status: (str) WPS job status
     :return status: (str) HySDS job status
     """
-    job_status = None
-    if wps_status not in WPS_STATUSES:
+    if wps_status not in WPS_TO_HYSDS_JOB_STATUS_MAP:
         statuses = ", ".join(str(status) for status in WPS_STATUSES)
-        raise ValueError("Invalid WPS status: {}. Valid values are: {}".format(wps_status, WPS_STATUSES))
-    elif wps_status == "Accepted":
-        job_status = "job-queued"
-    elif wps_status == "Running":
-        job_status = "job-started"
-    elif wps_status == "Succeeded":
-        job_status = "job-completed"
-    elif wps_status == "Failed":
-        job_status = "job-failed"     
-    elif wps_status == "Dismissed":
-        job_status = "job-revoked"
-    elif wps_status == "Deduped":
-        job_status = "job-deduped"
-    elif wps_status == "Offline":
-        job_status = "job-offline"
-    elif wps_status == "Deleted":
-        # TODO: HySDS does not support this status and 'Deleted' is not one of the base WPS job statuses.
-        # Treating this as a pass-through until there is consensus on HySDS-WPS mapping.
-        job_status = None
-    else:
-        job_status = None
-
-    return job_status
+        raise ValueError("Invalid WPS status: {}. Valid values are: {}".format(wps_status, statuses))
+    return WPS_TO_HYSDS_JOB_STATUS_MAP.get(wps_status)
 
 
 def get_status(job_status, wps_compliant=False):

--- a/api/utils/ogc_translate.py
+++ b/api/utils/ogc_translate.py
@@ -9,6 +9,10 @@ ns = {
     "ows": "http://www.opengis.net/ows/2.0"
 }
 
+# This list extends the recommended WPS job statuses to include statuses 'Deduped', 'Deleted', and 'Offline'.
+WPS_STATUSES = ["Accepted", "Running", "Succeeded", "Failed", "Dismissed", "Deduped", "Deleted", "Offline"]
+
+HYSDS_STATUSES= ["job-started", "job-completed", "job-queued", "job-failed", "job-deduped", "job-revoked", "job-offline"]
 
 def set_namespaces(xml_element):
     xml_element.set("xmlns:wps", "http://www.opengis.net/wps/2.0")
@@ -17,6 +21,37 @@ def set_namespaces(xml_element):
     xml_element.set("xmlns:ows", "http://www.opengis.net/ows/2.0")
 
     return xml_element
+
+def get_hysds_status_from_wps(wps_status):
+    """
+    Translate WPS job status to HySDS job status
+    :param status: (str) WPS job status
+    :return status: (str) HySDS job status
+    """
+    job_status = None
+    if wps_status not in WPS_STATUSES:
+        statuses = ", ".join(str(status) for status in WPS_STATUSES)
+        raise ValueError("Invalid WPS status: {}. Valid values are: {}".format(wps_status, WPS_STATUSES))
+    elif wps_status == "Accepted":
+        job_status = "job-queued"
+    elif wps_status == "Running":
+        job_status = "job-started"
+    elif wps_status == "Succeeded":
+        job_status = "job-completed"
+    elif wps_status == "Failed":
+        job_status = "job-failed"     
+    elif wps_status == "Dismissed":
+        job_status = "job-revoked"
+    elif wps_status == "Deduped":
+        job_status = "job-deduped"
+    elif wps_status == "Offline":
+        job_status = "job-offline"
+    elif wps_status == "Deleted":
+        job_status = None
+    else:
+        job_status = None
+
+    return job_status
 
 
 def get_status(job_status, wps_compliant=False):

--- a/api/utils/ogc_translate.py
+++ b/api/utils/ogc_translate.py
@@ -47,6 +47,8 @@ def get_hysds_status_from_wps(wps_status):
     elif wps_status == "Offline":
         job_status = "job-offline"
     elif wps_status == "Deleted":
+        # TODO: HySDS does not support this status and 'Deleted' is not one of the base WPS job statuses.
+        # Treating this as a pass-through until there is consensus on HySDS-WPS mapping.
         job_status = None
     else:
         job_status = None

--- a/api/utils/ogc_translate.py
+++ b/api/utils/ogc_translate.py
@@ -13,6 +13,15 @@ ns = {
 WPS_STATUSES = ["Accepted", "Running", "Succeeded", "Failed", "Dismissed", "Deduped", "Deleted", "Offline"]
 
 HYSDS_STATUSES= ["job-started", "job-completed", "job-queued", "job-failed", "job-deduped", "job-revoked", "job-offline"]
+WPS_TO_HYSDS_JOB_STATUS_MAP = {
+ "Accepted": "job-queued",
+ "Running": "job-started",
+ "Succeeded": "job-completed",
+ "Failed": "job-failed",
+ "Dismissed": "job-revoked",
+ "Deduped": "job-deduped",
+ "Deleted": None, 
+ "Offline": "job-offline"}
 
 def set_namespaces(xml_element):
     xml_element.set("xmlns:wps", "http://www.opengis.net/wps/2.0")


### PR DESCRIPTION
- added query params supported by the Mozart API to the job-list endpoint
- added option to return just a list of job id's or full job details

Testing:
Sample cURL request with a subset of the query parameters added for username `mlucas`:
`https://api.dit.maap-project.org/api/dps/job/mlucas/list?offset=0&status=job-revoked&page_size=3&priority=0&queue=maap-dps-worker-8gb`

closes #130 