### PR TITLE
Auto-populate job submitter username

### DIFF
--- a/api/endpoints/job.py
+++ b/api/endpoints/job.py
@@ -48,12 +48,14 @@ class Submit(Resource):
         logging.info("Dedup: {}".format(dedup))
         logging.info("Identifier: {}".format(identifier))
 
+        user = get_authorized_user()
+
         # validate the inputs provided by user against the registered spec for the job
         try:
             hysdsio_type = job_type.replace("job-", "hysds-io-")
             hysds_io = hysds.get_hysds_io(hysdsio_type)
             logging.info("Found HySDS-IO: {}".format(hysds_io))
-            params = hysds.validate_job_submit(hysds_io, input_params)
+            params = hysds.validate_job_submit(hysds_io, input_params, user.username)
         except Exception as ex:
             return Response(ogc.get_exception(type="FailedJobSubmit", origin_process="Execute",
                             ex_message="Failed to submit job of type {}. Exception Message: {}"
@@ -61,7 +63,6 @@ class Submit(Resource):
 
         try:
             dedup = "false" if dedup is None else dedup
-            user = get_authorized_user()
             queue = job_queue.validate_or_get_queue(queue, job_type, user.id)
             job_time_limit = hysds_io.get("result").get("soft_time_limit", 86400)
             if job_queue.contains_time_limit(queue):

--- a/api/utils/hysds_util.py
+++ b/api/utils/hysds_util.py
@@ -560,7 +560,7 @@ def get_recommended_queue(job_type):
     return recommended_queue if recommended_queue != "" else api.utils.job_queue.get_default_queue().queue_name
 
 
-def validate_job_submit(hysds_io, user_params):
+def validate_job_submit(hysds_io, user_params, username):
     """
     Given user's input params and the hysds-io spec for the job type
     This function validates if all the input params were provided,
@@ -587,7 +587,7 @@ def validate_job_submit(hysds_io, user_params):
     """
     validated_params = dict()
     # do not miss the username in params
-    validated_params["username"] = user_params.get("username")
+    validated_params["username"] = username
     for p in known_params:
         if user_params.get(p) is not None:
             validated_params[p] = user_params.get(p)


### PR DESCRIPTION
Currently a manually-set username argument within the job submission request to the MAAP API overrides the authenticated user's username. Change this behavior so that the job submission process pulls the username from the token rather than the input params.

See: https://github.com/MAAP-Project/Community/issues/1180