### PR TITLE
ESA EDL System Account Token Issuance

### DIFF
--- a/api/auth/cas_auth.py
+++ b/api/auth/cas_auth.py
@@ -233,8 +233,13 @@ def start_member_session(cas_response, ticket, auto_create_member=False):
 
     member = db.session.query(Member).filter_by(username=usr).first()
     urs_access_token = get_cas_attribute_value(attributes, 'access_token')
+    is_esa_user = get_cas_attribute_value(attributes, 'iss') == settings.ESA_ISS_HOST
 
-    if member is None and auto_create_member:
+    if is_esa_user:
+        esa_system_account = db.session.query(Member).filter_by(username=settings.ESA_EDL_SYS_ACCOUNT).first()
+        urs_access_token = esa_system_account.urs_token
+
+    if member is None and (auto_create_member or is_esa_user):
         member = Member(first_name=get_cas_attribute_value(attributes, 'given_name'),
                         last_name=get_cas_attribute_value(attributes, 'family_name'),
                         username=usr,

--- a/api/settings.py
+++ b/api/settings.py
@@ -126,6 +126,10 @@ EMAIL_JPL_ADMINS = os.getenv('EMAIL_JPL_ADMINS', "")  # Use a comma to delimit e
 # PORTAL PATHS
 PORTAL_ADMIN_DASHBOARD_PATH = os.getenv('PORTAL_ADMIN_DASHBOARD_PATH', '')
 
+# ESA Interoperability
+ESA_ISS_HOST = os.getenv('ESA_ISS_HOST', "")
+ESA_EDL_SYS_ACCOUNT = os.getenv('ESA_EDL_SYS_ACCOUNT', "")
+
 CLIENT_SETTINGS = {
     "maap_endpoint": {
         "search_granule_url": "cmr/granules",


### PR DESCRIPTION
This PR implements token issuance for approved ESA users using a dedicated EDL (Earthdata Login) system account. When ESA users authenticate through CAS, they will automatically receive access tokens from a pre-configured ESA system account in order to gain access to NASA DAAC resources.