### PR TITLE
Fix ESA auto account creation to set proper role and status

### DIFF
--- a/api/auth/cas_auth.py
+++ b/api/auth/cas_auth.py
@@ -20,7 +20,8 @@ from api.utils.url_util import proxied_url
 import ast
 import socket # For socket.timeout
 from xml.parsers.expat import ExpatError # For XML parsing errors
-
+from api.models.role import Role
+from api.auth.security import MEMBER_STATUS_ACTIVE, MEMBER_STATUS_SUSPENDED
 from api.utils.security_utils import AuthenticationError, ExternalServiceError
 
 
@@ -249,7 +250,10 @@ def start_member_session(cas_response, ticket, auto_create_member=False):
                         username=usr,
                         email=get_cas_attribute_value(attributes, 'email'),
                         organization=get_cas_attribute_value(attributes, 'organization'),
-                        urs_token=urs_access_token)
+                        urs_token=urs_access_token,
+                        role_id=Role.ROLE_MEMBER if is_esa_user else Role.ROLE_GUEST,
+                        status=MEMBER_STATUS_ACTIVE if is_esa_user else MEMBER_STATUS_SUSPENDED,
+                        creation_date=datetime.utcnow())
         try:
             db.session.add(member)
         except Exception as e:


### PR DESCRIPTION
## Summary
Fixes a bug in the ESA auto account creation flow where new members were not being assigned the correct role and status upon creation.

## Changes
- Added imports for `Role` model and member status constants (`MEMBER_STATUS_ACTIVE`, `MEMBER_STATUS_SUSPENDED`)
- Updated `start_member_session()` in [cas_auth.py](api/auth/cas_auth.py#L253) to set:
  - `role_id`: `ROLE_MEMBER` for ESA users, `ROLE_GUEST` otherwise
  - `status`: `MEMBER_STATUS_ACTIVE` for ESA users, `MEMBER_STATUS_SUSPENDED` otherwise  
  - `creation_date`: Current UTC timestamp