### PR TITLE
Improve job filtering

### DIFF
--- a/api/endpoints/ogc.py
+++ b/api/endpoints/ogc.py
@@ -23,7 +23,7 @@ from api.models.member import Member as Member_db
 
 from api.utils import job_queue
 from api.utils.ogc_process_util import (
-    create_process_deployment, get_cwl_metadata, CWL_METADATA,
+    create_process_deployment, get_cwl_metadata,
     trigger_gitlab_pipeline, create_and_commit_deployment, generate_error, get_hysds_process_name, 
     get_process_from_hysds_name, determineDatetimeInRange, parse_rfc3339_datetime,
     DEPLOYED_PROCESS_STATUS, INITIAL_JOB_STATUS, UNDEPLOYED_PROCESS_STATUS, HREF_LANG
@@ -693,7 +693,7 @@ class Status(Resource):
             "type": None,
             "status": current_status
         }
-        fields_to_specify = request.args.get("fields", "").split(",")
+        fields_to_specify = request.args.get("fields").split(',') if request.args.get("fields") else []
         job_info.update({
             "request": None,
             "message": None,
@@ -896,7 +896,7 @@ class Jobs(Resource):
 
         links = []
         job_list = []
-        fields_to_specify = request.args.get("fields", "").split(",")
+        fields_to_specify = request.args.get("fields").split(',') if request.args.get("fields") else []
         print("graceal1 printing")
         print(fields_to_specify)
         # Need to get the CWLs to return as links with the jobs 

--- a/api/endpoints/ogc.py
+++ b/api/endpoints/ogc.py
@@ -922,7 +922,7 @@ class Jobs(Resource):
                 hysds_status = job_info["status"]
                 ogc_status = ogc.hysds_to_ogc_status(hysds_status)
                 job_with_fields["status"] = ogc_status
-                job_with_fields["job_type"] = job_info["job"]["job_info"]["job_payload"]["job_type"]
+                job_with_fields["job_type"] = job_info["type"]
                 links.append({
                         "href": "/"+ns.name+"/job/"+job_with_fields["jobID"],
                         "rel": "self",
@@ -939,15 +939,21 @@ class Jobs(Resource):
                         # Information where we need to look up the process to get
                         elif field in ["keywords", "description", "title", "processID"]:
                             if not existing_process:
+                                print("graceal process was not existing so checking for name")
+                                print(job_with_fields["job_type"])
                                 existing_process = get_process_from_hysds_name(job_with_fields["job_type"])
                             print("graceal1 getting the field from the existing process ")
                             print(existing_process)
-                            #print(getattr(existing_process, field))
-                            print(existing_process[field])
+                            try:
+                                print(getattr(existing_process, field))
+                            except Exception as ex:
+                                print("graceal1 error using getattr way")
+                                print(ex)
+                            #print(existing_process[field])
                             if field == "processID":
                                 job_with_fields[field] = existing_process.process_id
                             else:
-                                job_with_fields[field] = existing_process[field]
+                                job_with_fields[field] = getattr(existing_process, field)
                         elif field == "created":
                             job_with_fields[field] = job_info["job"]["job_info"]["time_queued"]
                         elif field == "started":

--- a/api/endpoints/ogc.py
+++ b/api/endpoints/ogc.py
@@ -897,7 +897,6 @@ class Jobs(Resource):
         job_list = []
         fields_to_specify = request.args.get("fields", "").split(",")
         print("graceal1 printing")
-        print(response_body["jobs"])
         print(fields_to_specify)
         # Need to get the CWLs to return as links with the jobs 
         for job in response_body["jobs"]:

--- a/api/endpoints/ogc.py
+++ b/api/endpoints/ogc.py
@@ -912,7 +912,7 @@ class Jobs(Resource):
                 hysds_status = job[next(iter(job))]["status"]
                 ogc_status = ogc.hysds_to_ogc_status(hysds_status)
                 job_with_fields["status"] = ogc_status
-                job_with_fields["processID"]= job["processID"]
+                job_with_fields["processID"] = existing_process.process_id if existing_process else None
                 links.append({
                         "href": "/"+ns.name+"/job/"+job_with_fields["jobID"],
                         "rel": "self",

--- a/api/endpoints/ogc.py
+++ b/api/endpoints/ogc.py
@@ -714,11 +714,8 @@ class Status(Resource):
                 }
             ]
         })
-        print("graceal1 printing ")
-        print(request.args.get("getJobDetails"))
         get_job_details = request.args.get("getJobDetails", False)
         if get_job_details and get_job_details.lower() == "true":
-            print("graceal1 returning all job information")
             return job_info, status.HTTP_200_OK 
         # Add additional fields to the response that the user requested
         for field in fields_to_specify:
@@ -939,17 +936,7 @@ class Jobs(Resource):
                         # Information where we need to look up the process to get
                         elif field in ["keywords", "description", "title", "processID"]:
                             if not existing_process:
-                                print("graceal process was not existing so checking for name")
-                                print(job_with_fields["job_type"])
                                 existing_process = get_process_from_hysds_name(job_with_fields["job_type"])
-                            print("graceal1 getting the field from the existing process ")
-                            print(existing_process)
-                            try:
-                                print(getattr(existing_process, field))
-                            except Exception as ex:
-                                print("graceal1 error using getattr way")
-                                print(ex)
-                            #print(existing_process[field])
                             if field == "processID":
                                 job_with_fields[field] = existing_process.process_id
                             else:
@@ -964,13 +951,11 @@ class Jobs(Resource):
                             return generate_error(f"Invalid field requested {field}. Remember to separate fields with commas", status.HTTP_400_BAD_REQUEST)
                 except Exception as ex:
                     print("Error getting requested field from job")
-                    print(ex) # graceal delete this print statement 
                 existing_process = None
 
                 job_list.append(job_with_fields)
             except Exception as ex: 
                 print("Error getting job type or job status")
-                print(ex) # graceal delete this print statement
         response_body["links"] = links
         response_body["jobs"] = job_list
         return response_body, status.HTTP_200_OK

--- a/api/endpoints/ogc.py
+++ b/api/endpoints/ogc.py
@@ -717,7 +717,7 @@ class Status(Resource):
             if field in job_info:
                 response_body[field] = job_info[field]
             elif field not in ["jobID", "type", "status", "processID"]:
-                return generate_error(f"Invalid field requested {field}", status.HTTP_400_BAD_REQUEST)
+                return generate_error(f"Invalid field requested {field}. Remember to separate fields with commas", status.HTTP_400_BAD_REQUEST)
         return response_body, status.HTTP_200_OK 
     
     @api.doc(security="ApiKeyAuth")
@@ -914,7 +914,7 @@ class Jobs(Resource):
                 hysds_status = job[next(iter(job))]["status"]
                 ogc_status = ogc.hysds_to_ogc_status(hysds_status)
                 job_with_fields["status"] = ogc_status
-                job_with_fields["job_type"] = job["job"]["job_info"]["job_payload"]["job_type"]
+                job_with_fields["job_type"] = job[next(iter(job))]["job"]["job_info"]["job_payload"]["job_type"]
                 links.append({
                         "href": "/"+ns.name+"/job/"+job_with_fields["jobID"],
                         "rel": "self",
@@ -927,7 +927,7 @@ class Jobs(Resource):
                     if field in job:
                         job_with_fields[field] = job[field]
                     elif field not in ["type", "status", "jobID"]:
-                        return generate_error(f"Invalid field requested {field}", status.HTTP_400_BAD_REQUEST)
+                        return generate_error(f"Invalid field requested {field}. Remember to separate fields with commas", status.HTTP_400_BAD_REQUEST)
 
                 job_list.append(job_with_fields)
             except Exception as ex: 

--- a/api/endpoints/ogc.py
+++ b/api/endpoints/ogc.py
@@ -681,9 +681,9 @@ class Status(Resource):
         submitted_time = time_start = time_end = None
         try:
             current_status = ogc.hysds_to_ogc_status(current_status)
-            submitted_time = job_info["job"]["job_info"]["time_queued"]
-            time_start = job_info["job"]["job_info"]["time_start"]
-            time_end = job_info["job"]["job_info"]["time_end"]
+            submitted_time = response["job"]["job_info"]["time_queued"]
+            time_start = response["job"]["job_info"]["time_start"]
+            time_end = response["job"]["job_info"]["time_end"]
         except Exception as ex:
             print(ex)
             print(f"ERROR getting times or status for job {job_id}")
@@ -716,7 +716,8 @@ class Status(Resource):
         })
         print("graceal1 printing ")
         print(request.args.get("getJobDetails"))
-        if request.args.get("getJobDetails", False):
+        get_job_details = request.args.get("getJobDetails", False)
+        if get_job_details and get_job_details.lower() == "true":
             print("graceal1 returning all job information")
             return job_info, status.HTTP_200_OK 
         # Add additional fields to the response that the user requested
@@ -737,6 +738,7 @@ class Status(Resource):
         response_body = dict()
         # Since this can take a long time, we dont wait by default.
         wait_for_completion = request.args.get("waitForCompletion", False)
+        wait_for_completion = wait_for_completion and wait_for_completion.lower() == "true"
 
         try:
             # check if job is non-running and exists
@@ -791,7 +793,7 @@ class Jobs(Resource):
     parser.add_argument("tag", type=str, help="User-defined job tag", required=False)
     parser.add_argument("queue", type=str, help="Submitted job queue", required=False)
     parser.add_argument("priority", type=int, help="Job priority, 0-9", required=False)
-    parser.add_argument("getJobDetails", type=str, help="Return full details if True. "
+    parser.add_argument("getJobDetails", type=bool, help="Return full details if True. "
                                                            "List of job id's if false. Default True.", required=False)
     parser.add_argument("fields", type=int, help="Fields to specify in the job response", required=False)
 
@@ -939,7 +941,8 @@ class Jobs(Resource):
                             if not existing_process:
                                 existing_process = get_process_from_hysds_name(job_with_fields["job_type"])
                             print("graceal1 getting the field from the existing process ")
-                            print(getattr(existing_process, field))
+                            print(existing_process)
+                            #print(getattr(existing_process, field))
                             print(existing_process[field])
                             if field == "processID":
                                 job_with_fields[field] = existing_process.process_id

--- a/api/models/deployment.py
+++ b/api/models/deployment.py
@@ -12,7 +12,7 @@ class Deployment(Base):
     cwl_link = db.Column(db.String(), nullable=False)
     id = db.Column(db.String(), nullable=False)
     version = db.Column(db.String(), nullable=False)
-    deployer = db.Column(db.Integer, db.ForeignKey('member.id'), nullable=False)
+    deployer = db.Column(db.String(), db.ForeignKey('member.username'), nullable=False)
     author = db.Column(db.String(), nullable=True)
     process_id= db.Column(db.String(), nullable=True)
     title = db.Column(db.String(), nullable=True)

--- a/api/models/process.py
+++ b/api/models/process.py
@@ -8,7 +8,7 @@ class Process(Base):
     id = db.Column(db.String(), nullable=False)
     version = db.Column(db.String(), nullable=False)
     cwl_link = db.Column(db.String(), nullable=False)
-    deployer = db.Column(db.Integer, db.ForeignKey('member.id'), nullable=False)
+    deployer = db.Column(db.String(), db.ForeignKey('member.username'), nullable=False)
     author = db.Column(db.String(), nullable=True)
     # Status is either deployed or undeployed 
     status = db.Column(db.String(), nullable=False)

--- a/api/utils/ogc_process_util.py
+++ b/api/utils/ogc_process_util.py
@@ -40,7 +40,8 @@ def get_process_from_hysds_name(hysds_name):
     main_part, version = hysds_name.rsplit(':', 1)
     id_part, user_id = main_part.rsplit('_', 1)
     id = id_part.replace('job-', '', 1)
-    return db.session.query(Process_db).filter_by(id=id,version=version,deployer=user_id,status=DEPLOYED_PROCESS_STATUS).first()
+    user = db.session.query(Member).filter_by(id=user_id).first()
+    return db.session.query(Process_db).filter_by(id=id,version=version,deployer=user.username,status=DEPLOYED_PROCESS_STATUS).first()
 
 def generate_error(detail, error_status, error_type=None):
     """Generates a standardized error response body and status code."""
@@ -83,7 +84,7 @@ def create_and_commit_deployment(metadata, pipeline, user, existing_process=None
         title=metadata.title,
         description=metadata.description,
         keywords=metadata.keywords,
-        deployer=user.id,
+        deployer=user.username,
         author=metadata.author,
         pipeline_id=pipeline.id,
         github_url=metadata.github_url,
@@ -266,7 +267,7 @@ def create_process_deployment(cwl_link, user_id, ignore_existing=False):
             id=metadata.id, version=metadata.version, status=DEPLOYED_PROCESS_STATUS
         ).first()
         
-        if not ignore_existing and existing_process and existing_process.deployer == user.id:
+        if not ignore_existing and existing_process and existing_process.deployer == user.username:
             current_app.logger.debug(f"Duplicate process found for user {user.id}")
             response_body, code = generate_error(
                 "Duplicate process. Use PUT to modify existing process if you originally published it.", 


### PR DESCRIPTION
Changes:
- minimum being returned for jobs endpoints are 
```
/jobs -- status, jobID, type (always process), HySDS algorithm name 
/jobs/{job_id} -- status, jobID, type (always process), processID
```
- Users can request more fields with the `fields` parameter separated by ,'s 
   - requesting fields is a little more complex for the list jobs endpoint because a lot of the fields are nested- I added code to handle field requests for keywords, description, title, processID, created, started, finished. An idea to handle this problem to allow all fields for a job to be accessible is for the user to request nested parameters separated by : i.e. requesting time_start would look like "job:job_info:time_start" 
- /jobs/{job_id} can be passed getJobDetails as true to see all details about the job no matter what fields you pass in 
- error handling if a value for the fields parameter is invalid 
- responses at jobs endpoints now return jobID instead of id (fits [OGC](https://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/schemas/statusInfo.yaml))
- deployer is now stored in the process table as a username. This reduces the queries to the members table to get the id/ username mapping because now we don't make that query for every process for GET /processes. I had to add more queries to make this change, but no more than 1 query per request so this approach is more efficient 
- fixed a bug where waitForCompletion field would be true if any value was passed for it 
- job list being returned is no longer nested in a dictionary where the key is the jobID because this is not OGC compliant 

This is deployed on DIT right now if you want to test