### PR TITLE
Feature/s3 bucket auth

### DIFF
--- a/.devcontainer/Dockerfile.devcontainer
+++ b/.devcontainer/Dockerfile.devcontainer
@@ -1,7 +1,8 @@
 FROM python:3.9 as test-builder
 
 # Install Poetry
-RUN curl -sSL https://install.python-poetry.org | python3 -
+RUN curl -sSL https://install.python-poetry.org | python3 - --version 2.2.1 && \
+    export PATH="/root/.local/bin:$PATH" 
 
 ENV PATH="${PATH}:/root/.local/bin" \
     POETRY_NO_INTERACTION=1 \

--- a/api/endpoints/admin.py
+++ b/api/endpoints/admin.py
@@ -12,7 +12,9 @@ from api.schemas.pre_approved_schema import PreApprovedSchema
 from datetime import datetime
 import json
 from api.utils import job_queue
+from api.utils import s3_access
 from api.utils.http_util import err_response
+from api.models.organization_s3_access import OrganizationS3Access
 
 log = logging.getLogger(__name__)
 ns = api.namespace('admin', description='Operations related to the MAAP admin')
@@ -201,3 +203,93 @@ class PreApprovedEmails(Resource):
             raise
 
         return {"code": status.HTTP_200_OK, "message": "Successfully deleted {}.".format(email)}
+
+
+@ns.route('/s3-access')
+class S3AccessList(Resource):
+
+    @api.doc(security='ApiKeyAuth')
+    @login_required(role=Role.ROLE_ADMIN)
+    def get(self):
+        """
+        Lists all organization S3 bucket access entries
+        :return:
+        """
+        return s3_access.get_all_s3_access()
+
+    @api.doc(security='ApiKeyAuth')
+    @login_required(role=Role.ROLE_ADMIN)
+    def post(self):
+        """
+        Create new organization S3 bucket access entry.
+
+        Format of JSON to post:
+        {
+            "org_id": 1,
+            "bucket_name": "my-bucket",
+            "bucket_prefix": "optional/prefix"
+        }
+        """
+
+        req_data = request.get_json()
+        if not isinstance(req_data, dict):
+            return err_response("Valid JSON body object required.")
+
+        org_id = req_data.get("org_id")
+        if not isinstance(org_id, int) or not org_id:
+            return err_response("Valid org_id is required.")
+
+        bucket_name = req_data.get("bucket_name", "")
+        if not isinstance(bucket_name, str) or not bucket_name:
+            return err_response("Valid bucket_name is required.")
+
+        bucket_prefix = req_data.get("bucket_prefix")
+
+        new_entry = s3_access.create_s3_access(org_id, bucket_name, bucket_prefix)
+        return new_entry
+
+
+@ns.route('/s3-access/<int:access_id>')
+class S3AccessEntry(Resource):
+
+    @api.doc(security='ApiKeyAuth')
+    @login_required(role=Role.ROLE_ADMIN)
+    def put(self, access_id):
+        """
+        Update organization S3 bucket access entry. Only supplied fields are updated.
+        """
+
+        if not access_id:
+            return err_response("S3 access id is required.")
+
+        req_data = request.get_json()
+        if not isinstance(req_data, dict):
+            return err_response("Valid JSON body object required.")
+
+        access = db.session.query(OrganizationS3Access).filter_by(id=access_id).first()
+
+        if access is None:
+            return err_response(msg="No S3 access entry found with id " + str(access_id), code=status.HTTP_404_NOT_FOUND)
+
+        org_id = req_data.get("org_id")
+        bucket_name = req_data.get("bucket_name")
+        bucket_prefix = req_data.get("bucket_prefix")
+
+        updated_entry = s3_access.update_s3_access(access, org_id, bucket_name, bucket_prefix)
+        return updated_entry
+
+    @api.doc(security='ApiKeyAuth')
+    @login_required(role=Role.ROLE_ADMIN)
+    def delete(self, access_id):
+        """
+        Delete organization S3 bucket access entry
+        """
+
+        access = db.session.query(OrganizationS3Access).filter_by(id=access_id).first()
+
+        if access is None:
+            return err_response(msg="S3 access entry does not exist", code=status.HTTP_404_NOT_FOUND)
+
+        s3_access.delete_s3_access(access_id)
+
+        return {"code": status.HTTP_200_OK, "message": "Successfully deleted S3 access entry {}.".format(access_id)}

--- a/api/endpoints/admin.py
+++ b/api/endpoints/admin.py
@@ -227,7 +227,8 @@ class S3AccessList(Resource):
         {
             "org_id": 1,
             "bucket_name": "my-bucket",
-            "bucket_prefix": "optional/prefix"
+            "bucket_prefix": "optional/prefix",
+            "readonly": false
         }
         """
 
@@ -244,8 +245,9 @@ class S3AccessList(Resource):
             return err_response("Valid bucket_name is required.")
 
         bucket_prefix = req_data.get("bucket_prefix")
+        readonly = req_data.get("readonly", False)
 
-        new_entry = s3_access.create_s3_access(org_id, bucket_name, bucket_prefix)
+        new_entry = s3_access.create_s3_access(org_id, bucket_name, bucket_prefix, readonly)
         return new_entry
 
 
@@ -274,8 +276,9 @@ class S3AccessEntry(Resource):
         org_id = req_data.get("org_id")
         bucket_name = req_data.get("bucket_name")
         bucket_prefix = req_data.get("bucket_prefix")
+        readonly = req_data.get("readonly")
 
-        updated_entry = s3_access.update_s3_access(access, org_id, bucket_name, bucket_prefix)
+        updated_entry = s3_access.update_s3_access(access, org_id, bucket_name, bucket_prefix, readonly)
         return updated_entry
 
     @api.doc(security='ApiKeyAuth')

--- a/api/endpoints/environments.json
+++ b/api/endpoints/environments.json
@@ -35,7 +35,7 @@
         "api_server": "api.dit.maap-project.org",
         "auth_server": "auth.dit.maap-project.org",
         "mas_server": "repo.dit.maap-project.org",
-        "workspace_bucket": "maap-staging-workspace",
+        "workspace_bucket": "maap-uat-workspace",
         "default_host": false
     },
     {

--- a/api/endpoints/environments.json
+++ b/api/endpoints/environments.json
@@ -16,7 +16,7 @@
         "auth_server": "auth.uat.maap-project.org",
         "mas_server": "repo.uat.maap-project.org",
         "edsc_server": "ade.uat.maap-project.org:30052",
-        "workspace_bucket": "maap-staging-workspace",
+        "workspace_bucket": "maap-uat-workspace",
         "default_host": false
     },
     {

--- a/api/endpoints/members.py
+++ b/api/endpoints/members.py
@@ -23,6 +23,7 @@ from api.utils.email_util import send_user_status_update_active_user_email, \
     send_user_status_update_suspended_user_email, send_user_status_change_email, \
     send_welcome_to_maap_active_user_email, send_welcome_to_maap_suspended_user_email
 from api.endpoints.environment import get_config_from_api
+from api.utils.s3_access import get_user_s3_access
 from api.models.pre_approved import PreApproved
 from datetime import datetime, timezone
 import json
@@ -737,58 +738,119 @@ class AwsAccessUserBucketCredentials(Resource):
         if not maap_user:
             return Response('Unauthorized', status=401)
 
-        # Guaranteed to at least always return default 
+        # Guaranteed to at least always return default
         config = get_config_from_api(request.host)
         workspace_bucket = config["workspace_bucket"]
 
-        # Allow bucket access to just the user's workspace directory
-        policy = f'''{{"Version": "2012-10-17",
-            "Statement": [
-                {{
-                    "Sid": "GrantAccessToUserFolder",
-                    "Effect": "Allow",
-                    "Action": [
-                        "s3:ListBucket",
-                        "s3:DeleteObject",
-                        "s3:GetObject",
-                        "s3:PutObject",
-                        "s3:RestoreObject",
-                        "s3:ListMultipartUploadParts",
-                        "s3:AbortMultipartUpload"
-                    ],
-                    "Resource": [
-                        "arn:aws:s3:::{workspace_bucket}/{maap_user.username}/*"
-                    ]
-                }},
-                {{
-                    "Sid": "GrantListAccess",
+        # Build the base policy statements for the user's workspace directory
+        statements = [
+            {
+                "Sid": "GrantAccessToUserFolder",
+                "Effect": "Allow",
+                "Action": [
+                    "s3:ListBucket",
+                    "s3:DeleteObject",
+                    "s3:GetObject",
+                    "s3:PutObject",
+                    "s3:RestoreObject",
+                    "s3:ListMultipartUploadParts",
+                    "s3:AbortMultipartUpload"
+                ],
+                "Resource": [
+                    f"arn:aws:s3:::{workspace_bucket}/{maap_user.username}/*"
+                ]
+            },
+            {
+                "Sid": "GrantListAccess",
+                "Effect": "Allow",
+                "Action": [
+                    "s3:ListBucket"
+                ],
+                "Resource": f"arn:aws:s3:::{workspace_bucket}",
+                "Condition": {
+                    "StringLike": {
+                        "s3:prefix": [
+                            f"{maap_user.username}/*"
+                        ]
+                    }
+                }
+            }
+        ]
+
+        # Track all authorized S3 paths for the response
+        authorized_s3_paths = [
+            f"s3://{workspace_bucket}/{maap_user.username}"
+        ]
+
+        # Add custom org-level S3 bucket access
+        custom_access = get_user_s3_access(maap_user.id)
+        for i, entry in enumerate(custom_access):
+            bucket = entry['bucket_name']
+            prefix = entry['bucket_prefix']
+            resource_path = f"{bucket}/{prefix}/*" if prefix else f"{bucket}/*"
+            s3_path = f"s3://{bucket}/{prefix}" if prefix else f"s3://{bucket}"
+
+            statements.append({
+                "Sid": f"GrantCustomAccess{i}",
+                "Effect": "Allow",
+                "Action": [
+                    "s3:ListBucket",
+                    "s3:DeleteObject",
+                    "s3:GetObject",
+                    "s3:PutObject",
+                    "s3:RestoreObject",
+                    "s3:ListMultipartUploadParts",
+                    "s3:AbortMultipartUpload"
+                ],
+                "Resource": [
+                    f"arn:aws:s3:::{resource_path}"
+                ]
+            })
+
+            # Add list access with prefix condition if a prefix is set
+            if prefix:
+                statements.append({
+                    "Sid": f"GrantCustomListAccess{i}",
                     "Effect": "Allow",
                     "Action": [
                         "s3:ListBucket"
                     ],
-                    "Resource": "arn:aws:s3:::{workspace_bucket}",
-                    "Condition": {{
-                        "StringLike": {{
+                    "Resource": f"arn:aws:s3:::{bucket}",
+                    "Condition": {
+                        "StringLike": {
                             "s3:prefix": [
-                                "{maap_user.username}/*"
+                                f"{prefix}/*"
                             ]
-                        }}
-                    }}
-                }}
-            ]
-        }}'''
+                        }
+                    }
+                })
+            else:
+                statements.append({
+                    "Sid": f"GrantCustomListAccess{i}",
+                    "Effect": "Allow",
+                    "Action": [
+                        "s3:ListBucket"
+                    ],
+                    "Resource": f"arn:aws:s3:::{bucket}"
+                })
+
+            authorized_s3_paths.append(s3_path)
+
+        policy = json.dumps({
+            "Version": "2012-10-17",
+            "Statement": statements
+        })
 
         # Call the assume_role method of the STSConnection object
         assumed_role_object = sts_client.assume_role(
             RoleArn=settings.WORKSPACE_BUCKET_ARN,
             RoleSessionName=f'workspace-session-{maap_user.username}',
             Policy=policy,
-            DurationSeconds=(60 * 60)
+            DurationSeconds=(60 * 60 * 12)  # 12 hours, which is the max allowed by AWS for a custom policy with assume_role
         )
 
         response = jsonify(
-            aws_bucket_name=workspace_bucket,
-            aws_bucket_prefix=maap_user.username,
+            authorized_s3_paths=authorized_s3_paths,
             aws_access_key_id=assumed_role_object['Credentials']['AccessKeyId'],
             aws_secret_access_key=assumed_role_object['Credentials']['SecretAccessKey'],
             aws_session_token=assumed_role_object['Credentials']['SessionToken'],

--- a/api/endpoints/members.py
+++ b/api/endpoints/members.py
@@ -754,11 +754,13 @@ class AwsAccessUserBucketCredentials(Resource):
         )
 
         response = jsonify(
-            authorized_s3_paths=authorized_s3_paths,
-            aws_access_key_id=assumed_role_object['Credentials']['AccessKeyId'],
-            aws_secret_access_key=assumed_role_object['Credentials']['SecretAccessKey'],
-            aws_session_token=assumed_role_object['Credentials']['SessionToken'],
-            aws_session_expiration=assumed_role_object['Credentials']['Expiration'].strftime("%Y-%m-%d %H:%M:%S%z")
+            credentials={
+                "aws_access_key_id": assumed_role_object['Credentials']['AccessKeyId'],
+                "aws_secret_access_key": assumed_role_object['Credentials']['SecretAccessKey'],
+                "aws_session_token": assumed_role_object['Credentials']['SessionToken'],
+                "expires_at": assumed_role_object['Credentials']['Expiration'].strftime("%Y-%m-%dT%H:%M:%S%z")
+            },
+            authorized_s3_paths=authorized_s3_paths
         )
 
         response.headers.add('Access-Control-Allow-Origin', '*')

--- a/api/endpoints/members.py
+++ b/api/endpoints/members.py
@@ -23,7 +23,7 @@ from api.utils.email_util import send_user_status_update_active_user_email, \
     send_user_status_update_suspended_user_email, send_user_status_change_email, \
     send_welcome_to_maap_active_user_email, send_welcome_to_maap_suspended_user_email
 from api.endpoints.environment import get_config_from_api
-from api.utils.s3_access import get_user_s3_access
+from api.utils.s3_access import build_user_s3_policy
 from api.models.pre_approved import PreApproved
 from datetime import datetime, timezone
 import json
@@ -742,104 +742,8 @@ class AwsAccessUserBucketCredentials(Resource):
         config = get_config_from_api(request.host)
         workspace_bucket = config["workspace_bucket"]
 
-        # Build the base policy statements for the user's workspace directory
-        statements = [
-            {
-                "Sid": "GrantAccessToUserFolder",
-                "Effect": "Allow",
-                "Action": [
-                    "s3:ListBucket",
-                    "s3:DeleteObject",
-                    "s3:GetObject",
-                    "s3:PutObject",
-                    "s3:RestoreObject",
-                    "s3:ListMultipartUploadParts",
-                    "s3:AbortMultipartUpload"
-                ],
-                "Resource": [
-                    f"arn:aws:s3:::{workspace_bucket}/{maap_user.username}/*"
-                ]
-            },
-            {
-                "Sid": "GrantListAccess",
-                "Effect": "Allow",
-                "Action": [
-                    "s3:ListBucket"
-                ],
-                "Resource": f"arn:aws:s3:::{workspace_bucket}",
-                "Condition": {
-                    "StringLike": {
-                        "s3:prefix": [
-                            f"{maap_user.username}/*"
-                        ]
-                    }
-                }
-            }
-        ]
-
-        # Track all authorized S3 paths for the response
-        authorized_s3_paths = [
-            f"s3://{workspace_bucket}/{maap_user.username}"
-        ]
-
-        # Add custom org-level S3 bucket access
-        custom_access = get_user_s3_access(maap_user.id)
-        for i, entry in enumerate(custom_access):
-            bucket = entry['bucket_name']
-            prefix = entry['bucket_prefix']
-            resource_path = f"{bucket}/{prefix}/*" if prefix else f"{bucket}/*"
-            s3_path = f"s3://{bucket}/{prefix}" if prefix else f"s3://{bucket}"
-
-            statements.append({
-                "Sid": f"GrantCustomAccess{i}",
-                "Effect": "Allow",
-                "Action": [
-                    "s3:ListBucket",
-                    "s3:DeleteObject",
-                    "s3:GetObject",
-                    "s3:PutObject",
-                    "s3:RestoreObject",
-                    "s3:ListMultipartUploadParts",
-                    "s3:AbortMultipartUpload"
-                ],
-                "Resource": [
-                    f"arn:aws:s3:::{resource_path}"
-                ]
-            })
-
-            # Add list access with prefix condition if a prefix is set
-            if prefix:
-                statements.append({
-                    "Sid": f"GrantCustomListAccess{i}",
-                    "Effect": "Allow",
-                    "Action": [
-                        "s3:ListBucket"
-                    ],
-                    "Resource": f"arn:aws:s3:::{bucket}",
-                    "Condition": {
-                        "StringLike": {
-                            "s3:prefix": [
-                                f"{prefix}/*"
-                            ]
-                        }
-                    }
-                })
-            else:
-                statements.append({
-                    "Sid": f"GrantCustomListAccess{i}",
-                    "Effect": "Allow",
-                    "Action": [
-                        "s3:ListBucket"
-                    ],
-                    "Resource": f"arn:aws:s3:::{bucket}"
-                })
-
-            authorized_s3_paths.append(s3_path)
-
-        policy = json.dumps({
-            "Version": "2012-10-17",
-            "Statement": statements
-        })
+        # Build the STS policy and collect authorized paths
+        policy, authorized_s3_paths = build_user_s3_policy(workspace_bucket, maap_user.username, maap_user.id)
 
         # Call the assume_role method of the STSConnection object
         assumed_role_object = sts_client.assume_role(

--- a/api/models/organization_s3_access.py
+++ b/api/models/organization_s3_access.py
@@ -1,0 +1,15 @@
+from api.models import Base
+from api.maap_database import db
+
+
+class OrganizationS3Access(Base):
+    __tablename__ = 'organization_s3_access'
+
+    id = db.Column(db.Integer, primary_key=True)
+    org_id = db.Column(db.Integer, db.ForeignKey('organization.id'), nullable=False)
+    bucket_name = db.Column(db.String(), nullable=False)
+    bucket_prefix = db.Column(db.String(), nullable=True)
+    creation_date = db.Column(db.DateTime())
+
+    def __repr__(self):
+        return "<OrganizationS3Access(id={self.id!r})>".format(self=self)

--- a/api/models/organization_s3_access.py
+++ b/api/models/organization_s3_access.py
@@ -9,6 +9,7 @@ class OrganizationS3Access(Base):
     org_id = db.Column(db.Integer, db.ForeignKey('organization.id'), nullable=False)
     bucket_name = db.Column(db.String(), nullable=False)
     bucket_prefix = db.Column(db.String(), nullable=True)
+    readonly = db.Column(db.Boolean(), nullable=False, default=False)
     creation_date = db.Column(db.DateTime())
 
     def __repr__(self):

--- a/api/schemas/organization_s3_access_schema.py
+++ b/api/schemas/organization_s3_access_schema.py
@@ -1,0 +1,9 @@
+from api.models.organization_s3_access import OrganizationS3Access
+from marshmallow_sqlalchemy import SQLAlchemyAutoSchema
+
+
+class OrganizationS3AccessSchema(SQLAlchemyAutoSchema):
+    class Meta:
+        model = OrganizationS3Access
+        include_fk = True
+        load_instance = True

--- a/api/utils/organization.py
+++ b/api/utils/organization.py
@@ -11,6 +11,7 @@ from api.models.member import Member
 from api.models.organization import Organization
 from api.models.organization_job_queue import OrganizationJobQueue
 from api.models.organization_membership import OrganizationMembership
+from api.models.organization_s3_access import OrganizationS3Access
 from api.schemas.organization_schema import OrganizationSchema
 
 log = logging.getLogger(__name__)
@@ -205,6 +206,17 @@ def delete_organization(org_id):
         except Exception as e:
             db.session.rollback()
             app.logger.error(f"Failed to clear job queues for organization {org_id}: {e}")
+            raise
+
+        # Clear S3 access entries
+        try:
+            db.session.execute(
+                db.delete(OrganizationS3Access).filter_by(org_id=org_id)
+            )
+            db.session.commit()
+        except Exception as e:
+            db.session.rollback()
+            app.logger.error(f"Failed to clear S3 access for organization {org_id}: {e}")
             raise
 
         try:

--- a/api/utils/s3_access.py
+++ b/api/utils/s3_access.py
@@ -67,6 +67,112 @@ def get_user_s3_access(user_id):
         raise ex
 
 
+def build_user_s3_policy(workspace_bucket, username, user_id):
+    """
+    Build an IAM policy document and list of authorized S3 paths for a user.
+    Includes the user's workspace bucket plus any custom org-level S3 access.
+
+    Returns:
+        tuple: (policy_json_string, authorized_s3_paths_list)
+    """
+    statements = [
+        {
+            "Sid": "GrantAccessToUserFolder",
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket",
+                "s3:DeleteObject",
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:RestoreObject",
+                "s3:ListMultipartUploadParts",
+                "s3:AbortMultipartUpload"
+            ],
+            "Resource": [
+                f"arn:aws:s3:::{workspace_bucket}/{username}/*"
+            ]
+        },
+        {
+            "Sid": "GrantListAccess",
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket"
+            ],
+            "Resource": f"arn:aws:s3:::{workspace_bucket}",
+            "Condition": {
+                "StringLike": {
+                    "s3:prefix": [
+                        f"{username}/*"
+                    ]
+                }
+            }
+        }
+    ]
+
+    authorized_s3_paths = [
+        f"s3://{workspace_bucket}/{username}"
+    ]
+
+    custom_access = get_user_s3_access(user_id)
+    for i, entry in enumerate(custom_access):
+        bucket = entry['bucket_name']
+        prefix = entry['bucket_prefix']
+        resource_path = f"{bucket}/{prefix}/*" if prefix else f"{bucket}/*"
+        s3_path = f"s3://{bucket}/{prefix}" if prefix else f"s3://{bucket}"
+
+        statements.append({
+            "Sid": f"GrantCustomAccess{i}",
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket",
+                "s3:DeleteObject",
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:RestoreObject",
+                "s3:ListMultipartUploadParts",
+                "s3:AbortMultipartUpload"
+            ],
+            "Resource": [
+                f"arn:aws:s3:::{resource_path}"
+            ]
+        })
+
+        if prefix:
+            statements.append({
+                "Sid": f"GrantCustomListAccess{i}",
+                "Effect": "Allow",
+                "Action": [
+                    "s3:ListBucket"
+                ],
+                "Resource": f"arn:aws:s3:::{bucket}",
+                "Condition": {
+                    "StringLike": {
+                        "s3:prefix": [
+                            f"{prefix}/*"
+                        ]
+                    }
+                }
+            })
+        else:
+            statements.append({
+                "Sid": f"GrantCustomListAccess{i}",
+                "Effect": "Allow",
+                "Action": [
+                    "s3:ListBucket"
+                ],
+                "Resource": f"arn:aws:s3:::{bucket}"
+            })
+
+        authorized_s3_paths.append(s3_path)
+
+    policy = json.dumps({
+        "Version": "2012-10-17",
+        "Statement": statements
+    })
+
+    return policy, authorized_s3_paths
+
+
 def create_s3_access(org_id, bucket_name, bucket_prefix):
     try:
         new_entry = OrganizationS3Access(

--- a/api/utils/s3_access.py
+++ b/api/utils/s3_access.py
@@ -1,0 +1,127 @@
+import json
+import logging
+from collections import namedtuple
+from datetime import datetime
+
+import sqlalchemy
+from sqlalchemy.exc import SQLAlchemyError
+from flask import current_app as app
+from api.maap_database import db
+from api.models.organization import Organization
+from api.models.organization_s3_access import OrganizationS3Access
+from api.schemas.organization_s3_access_schema import OrganizationS3AccessSchema
+
+log = logging.getLogger(__name__)
+
+
+def get_all_s3_access():
+    try:
+        result = []
+
+        entries = db.session.query(
+            OrganizationS3Access.id,
+            OrganizationS3Access.org_id,
+            OrganizationS3Access.bucket_name,
+            OrganizationS3Access.bucket_prefix,
+            OrganizationS3Access.creation_date,
+            Organization.name.label('org_name')
+        ).join(
+            Organization, Organization.id == OrganizationS3Access.org_id
+        ).order_by(Organization.name, OrganizationS3Access.bucket_name).all()
+
+        for e in entries:
+            result.append({
+                'id': e.id,
+                'org_id': e.org_id,
+                'org_name': e.org_name,
+                'bucket_name': e.bucket_name,
+                'bucket_prefix': e.bucket_prefix,
+                'creation_date': e.creation_date.strftime('%m/%d/%Y') if e.creation_date else None,
+            })
+
+        return result
+    except SQLAlchemyError as ex:
+        raise ex
+
+
+def get_user_s3_access(user_id):
+    try:
+        query = """select osa.id, osa.bucket_name, osa.bucket_prefix
+                    from organization_membership m
+                    inner join organization_s3_access osa on m.org_id = osa.org_id
+                    where m.member_id = {}""".format(user_id)
+        rows = db.session.execute(sqlalchemy.text(query))
+
+        Record = namedtuple('Record', rows.keys())
+        records = [Record(*r) for r in rows.fetchall()]
+
+        result = []
+        for r in records:
+            result.append({
+                'bucket_name': r.bucket_name,
+                'bucket_prefix': r.bucket_prefix,
+            })
+
+        return result
+    except SQLAlchemyError as ex:
+        raise ex
+
+
+def create_s3_access(org_id, bucket_name, bucket_prefix):
+    try:
+        new_entry = OrganizationS3Access(
+            org_id=org_id,
+            bucket_name=bucket_name,
+            bucket_prefix=bucket_prefix,
+            creation_date=datetime.utcnow()
+        )
+
+        try:
+            db.session.add(new_entry)
+            db.session.commit()
+        except Exception as e:
+            db.session.rollback()
+            app.logger.error(f"Failed to create S3 access entry for org {org_id}: {e}")
+            raise
+
+        schema = OrganizationS3AccessSchema()
+        return json.loads(schema.dumps(new_entry))
+
+    except SQLAlchemyError as ex:
+        raise ex
+
+
+def update_s3_access(access, org_id, bucket_name, bucket_prefix):
+    try:
+        if org_id is not None:
+            access.org_id = org_id
+        if bucket_name is not None:
+            access.bucket_name = bucket_name
+        if bucket_prefix is not None:
+            access.bucket_prefix = bucket_prefix
+
+        try:
+            db.session.commit()
+        except Exception as e:
+            db.session.rollback()
+            app.logger.error(f"Failed to update S3 access entry {access.id}: {e}")
+            raise
+
+        schema = OrganizationS3AccessSchema()
+        return json.loads(schema.dumps(access))
+
+    except SQLAlchemyError as ex:
+        raise ex
+
+
+def delete_s3_access(access_id):
+    try:
+        try:
+            db.session.query(OrganizationS3Access).filter_by(id=access_id).delete()
+            db.session.commit()
+        except Exception as e:
+            db.session.rollback()
+            app.logger.error(f"Failed to delete S3 access entry {access_id}: {e}")
+            raise
+    except SQLAlchemyError as ex:
+        raise ex

--- a/api/utils/s3_access.py
+++ b/api/utils/s3_access.py
@@ -23,6 +23,7 @@ def get_all_s3_access():
             OrganizationS3Access.org_id,
             OrganizationS3Access.bucket_name,
             OrganizationS3Access.bucket_prefix,
+            OrganizationS3Access.readonly,
             OrganizationS3Access.creation_date,
             Organization.name.label('org_name')
         ).join(
@@ -36,6 +37,7 @@ def get_all_s3_access():
                 'org_name': e.org_name,
                 'bucket_name': e.bucket_name,
                 'bucket_prefix': e.bucket_prefix,
+                'readonly': e.readonly,
                 'creation_date': e.creation_date.strftime('%m/%d/%Y') if e.creation_date else None,
             })
 
@@ -46,7 +48,7 @@ def get_all_s3_access():
 
 def get_user_s3_access(user_id):
     try:
-        query = """select osa.id, osa.bucket_name, osa.bucket_prefix
+        query = """select osa.id, osa.bucket_name, osa.bucket_prefix, osa.readonly
                     from organization_membership m
                     inner join organization_s3_access osa on m.org_id = osa.org_id
                     where m.member_id = {}""".format(user_id)
@@ -60,11 +62,28 @@ def get_user_s3_access(user_id):
             result.append({
                 'bucket_name': r.bucket_name,
                 'bucket_prefix': r.bucket_prefix,
+                'readonly': r.readonly,
             })
 
         return result
     except SQLAlchemyError as ex:
         raise ex
+
+
+S3_READ_WRITE_ACTIONS = [
+    "s3:ListBucket",
+    "s3:DeleteObject",
+    "s3:GetObject",
+    "s3:PutObject",
+    "s3:RestoreObject",
+    "s3:ListMultipartUploadParts",
+    "s3:AbortMultipartUpload"
+]
+
+S3_READ_ONLY_ACTIONS = [
+    "s3:ListBucket",
+    "s3:GetObject"
+]
 
 
 def build_user_s3_policy(workspace_bucket, username, user_id):
@@ -79,15 +98,7 @@ def build_user_s3_policy(workspace_bucket, username, user_id):
         {
             "Sid": "GrantAccessToUserFolder",
             "Effect": "Allow",
-            "Action": [
-                "s3:ListBucket",
-                "s3:DeleteObject",
-                "s3:GetObject",
-                "s3:PutObject",
-                "s3:RestoreObject",
-                "s3:ListMultipartUploadParts",
-                "s3:AbortMultipartUpload"
-            ],
+            "Action": S3_READ_WRITE_ACTIONS,
             "Resource": [
                 f"arn:aws:s3:::{workspace_bucket}/{username}/*"
             ]
@@ -110,28 +121,28 @@ def build_user_s3_policy(workspace_bucket, username, user_id):
     ]
 
     authorized_s3_paths = [
-        f"s3://{workspace_bucket}/{username}"
+        {
+            "bucket": workspace_bucket,
+            "prefix": username,
+            "uri": f"s3://{workspace_bucket}/{username}",
+            "type": "workspace",
+            "access": "read_write"
+        }
     ]
 
     custom_access = get_user_s3_access(user_id)
     for i, entry in enumerate(custom_access):
         bucket = entry['bucket_name']
         prefix = entry['bucket_prefix']
+        readonly = entry.get('readonly', False)
         resource_path = f"{bucket}/{prefix}/*" if prefix else f"{bucket}/*"
-        s3_path = f"s3://{bucket}/{prefix}" if prefix else f"s3://{bucket}"
+        actions = S3_READ_ONLY_ACTIONS if readonly else S3_READ_WRITE_ACTIONS
+        access_level = "read_only" if readonly else "read_write"
 
         statements.append({
             "Sid": f"GrantCustomAccess{i}",
             "Effect": "Allow",
-            "Action": [
-                "s3:ListBucket",
-                "s3:DeleteObject",
-                "s3:GetObject",
-                "s3:PutObject",
-                "s3:RestoreObject",
-                "s3:ListMultipartUploadParts",
-                "s3:AbortMultipartUpload"
-            ],
+            "Action": actions,
             "Resource": [
                 f"arn:aws:s3:::{resource_path}"
             ]
@@ -163,7 +174,13 @@ def build_user_s3_policy(workspace_bucket, username, user_id):
                 "Resource": f"arn:aws:s3:::{bucket}"
             })
 
-        authorized_s3_paths.append(s3_path)
+        authorized_s3_paths.append({
+            "bucket": bucket,
+            "prefix": prefix,
+            "uri": f"s3://{bucket}/{prefix}" if prefix else f"s3://{bucket}",
+            "type": "org",
+            "access": access_level
+        })
 
     policy = json.dumps({
         "Version": "2012-10-17",
@@ -173,12 +190,13 @@ def build_user_s3_policy(workspace_bucket, username, user_id):
     return policy, authorized_s3_paths
 
 
-def create_s3_access(org_id, bucket_name, bucket_prefix):
+def create_s3_access(org_id, bucket_name, bucket_prefix, readonly=False):
     try:
         new_entry = OrganizationS3Access(
             org_id=org_id,
             bucket_name=bucket_name,
             bucket_prefix=bucket_prefix,
+            readonly=readonly,
             creation_date=datetime.utcnow()
         )
 
@@ -197,7 +215,7 @@ def create_s3_access(org_id, bucket_name, bucket_prefix):
         raise ex
 
 
-def update_s3_access(access, org_id, bucket_name, bucket_prefix):
+def update_s3_access(access, org_id, bucket_name, bucket_prefix, readonly=None):
     try:
         if org_id is not None:
             access.org_id = org_id
@@ -205,6 +223,8 @@ def update_s3_access(access, org_id, bucket_name, bucket_prefix):
             access.bucket_name = bucket_name
         if bucket_prefix is not None:
             access.bucket_prefix = bucket_prefix
+        if readonly is not None:
+            access.readonly = readonly
 
         try:
             db.session.commit()

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 
 FROM python:3.9 as builder
 
-# Install Poetry
+# Install Poetry!
 RUN curl -sSL https://install.python-poetry.org | python3 - --version 2.2.1 && \
     export PATH="/root/.local/bin:$PATH" 
 

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -1,7 +1,8 @@
 FROM python:3.9 as test-builder
 
 # Install Poetry
-RUN curl -sSL https://install.python-poetry.org | python3 -
+RUN curl -sSL https://install.python-poetry.org | python3 - --version 2.2.1 && \
+    export PATH="/root/.local/bin:$PATH" 
 
 ENV PATH="${PATH}:/root/.local/bin" \
     POETRY_NO_INTERACTION=1 \

--- a/plan/TEST_IMPLEMENTATION_PLAN.md
+++ b/plan/TEST_IMPLEMENTATION_PLAN.md
@@ -38,7 +38,8 @@ This document provides a comprehensive step-by-step plan to implement the tests 
 FROM python:3.9 as test-builder
 
 # Install Poetry
-RUN curl -sSL https://install.python-poetry.org | python3 -
+RUN curl -sSL https://install.python-poetry.org | python3 - --version 2.2.1 && \
+    export PATH="/root/.local/bin:$PATH" 
 
 ENV PATH="${PATH}:/root/.local/bin" \
     POETRY_NO_INTERACTION=1 \


### PR DESCRIPTION
This PR adds organization-level S3 bucket access management, allowing admins to grant orgs access to custom S3 buckets/prefixes beyond the default user workspace.

When users request STS credentials via /api/members/self/awsAccess/workspaceBucket, the IAM policy now dynamically includes any custom S3 buckets their organizations have been granted, and the response returns an authorized_s3_paths array listing all accessible paths.

### Endpoint response format change for `awsAccess/workspaceBucket`

The `/api/members/self/awsAccess/workspaceBucket` response replaces aws_bucket_name and aws_bucket_prefix with authorized_s3_paths (an array of s3:// URIs). Consumers that read aws_bucket_name/aws_bucket_prefix will need to be updated to use authorized_s3_paths[0] or iterate the full list.

Related admin console change: https://github.com/MAAP-Project/maap-wp-plugin/commit/8c72f748f7179c4d755e8d8dde275bbd389b027d