### PR TITLE
Shorter error messages

### DIFF
--- a/api/utils/hysds_util.py
+++ b/api/utils/hysds_util.py
@@ -598,8 +598,7 @@ def validate_job_submit(hysds_io, user_params, username):
             if known_params.get(p).get("default") is not None:
                 validated_params[p] = known_params.get(p).get("default")
             else:
-                raise ValueError("Parameter {} missing from inputs. Didn't find any default set for it in "
-                                 "algorithm specification. Please specify it and attempt to submit.".format(p))
+                raise ValueError("Parameter {} missing from inputs. No default set in algorithm spec. Please specify and resubmit.".format(p))
     return validated_params
 
 


### PR DESCRIPTION
Could not find any other problems besides what Marjorie said:
FailedJobSubmit: Parameter sentinel_granule missing from inputs. Didn't find any default set for it in algorithm specification. Please specify it and attempt to submit.
Most end with an error message that could be too long but we should just give the user as much of the error message as possible, the toast notification will just truncate it for us
I checked ogc.py, ogc_process_util.py and hysds_util.py for problems