### PR TITLE
Bug/status running job

### DIFF
--- a/api/endpoints/ogc.py
+++ b/api/endpoints/ogc.py
@@ -712,14 +712,10 @@ class Status(Resource):
             print(ex)
             print(f"ERROR getting tags for job {job_id}")
 
-        # Assign the process name/ ID which is only available once the job status is finished 
-        process_name = get_process_name_from_hysds_name(job_type) if job_type else "Error getting process name"
-        processID = existing_process.process_id if existing_process else "Error getting process ID"
-
         # Bare minimum response body to pass back
         response_body = {
             "jobID": job_id,
-            "processID": processID,
+            "processID": existing_process.process_id if existing_process else "Error getting process ID",
             # TODO graceal should this be hard coded in if the example options are process, wps, openeo?
             "type": None,
             "status": current_status
@@ -728,7 +724,6 @@ class Status(Resource):
         job_info.update(response_body)
         fields_to_specify = request.args.get("fields").split(',') if request.args.get("fields") else []
 
-        # Assign the process name which is only available once the job status is finished 
         job_info.update({
             "request": None,
             "message": None,
@@ -738,7 +733,7 @@ class Status(Resource):
             "updated": None,
             "progress": None,
             "tags": tags,
-            "process_name": process_name,
+            "process_name": get_process_name_from_hysds_name(job_type) if job_type else "Error getting process name",
             "links": [
                 {
                     "href": "/"+ns.name+"/jobs/"+str(job_id),

--- a/api/endpoints/ogc.py
+++ b/api/endpoints/ogc.py
@@ -675,6 +675,7 @@ class Status(Resource):
             return response_body, status.HTTP_500_INTERNAL_SERVER_ERROR 
 
         try:
+            job_type=None
             response = hysds.get_mozart_job(job_id)
             if response and response["type"]:
                 job_type = response["type"]
@@ -722,6 +723,15 @@ class Status(Resource):
         # job_info represents all additional fields a user can request about the job
         job_info.update(response_body)
         fields_to_specify = request.args.get("fields").split(',') if request.args.get("fields") else []
+
+        # Assign the process name which is only available once the job status is finished 
+        print("graceal1 pending status names")
+        print(ogc.OGC_PENDING_STATUSES)
+        process_name = None
+        if ogc.OGC_PENDING_STATUSES.includes(current_status):
+            process_name = "Pending job completion"
+        else:
+            process_name = get_process_name_from_hysds_name(job_type) if job_type else "Error"
         job_info.update({
             "request": None,
             "message": None,
@@ -731,7 +741,7 @@ class Status(Resource):
             "updated": None,
             "progress": None,
             "tags": tags,
-            "process_name": get_process_name_from_hysds_name(job_type),
+            "process_name": process_name,
             "links": [
                 {
                     "href": "/"+ns.name+"/jobs/"+str(job_id),

--- a/api/endpoints/ogc.py
+++ b/api/endpoints/ogc.py
@@ -712,13 +712,9 @@ class Status(Resource):
             print(ex)
             print(f"ERROR getting tags for job {job_id}")
 
-        process_name = None
-        processID = None
-        if current_status in ogc.OGC_PENDING_STATUSES:
-            process_name = processID = "Pending job completion"
-        else:
-            process_name = get_process_name_from_hysds_name(job_type) if job_type else "Error getting process name"
-            processID = existing_process.process_id if existing_process else "Error getting process ID"
+        # Assign the process name/ ID which is only available once the job status is finished 
+        process_name = get_process_name_from_hysds_name(job_type) if job_type else "Error getting process name"
+        processID = existing_process.process_id if existing_process else "Error getting process ID"
 
         # Bare minimum response body to pass back
         response_body = {

--- a/api/endpoints/ogc.py
+++ b/api/endpoints/ogc.py
@@ -712,10 +712,18 @@ class Status(Resource):
             print(ex)
             print(f"ERROR getting tags for job {job_id}")
 
+        process_name = None
+        processID = None
+        if current_status in ogc.OGC_PENDING_STATUSES:
+            process_name = processID = "Pending job completion"
+        else:
+            process_name = get_process_name_from_hysds_name(job_type) if job_type else "Error getting process name"
+            processID = existing_process.process_id if existing_process else "Error getting process ID"
+
         # Bare minimum response body to pass back
         response_body = {
             "jobID": job_id,
-            "processID": existing_process.process_id if existing_process else None,
+            "processID": processID,
             # TODO graceal should this be hard coded in if the example options are process, wps, openeo?
             "type": None,
             "status": current_status
@@ -725,13 +733,6 @@ class Status(Resource):
         fields_to_specify = request.args.get("fields").split(',') if request.args.get("fields") else []
 
         # Assign the process name which is only available once the job status is finished 
-        print("graceal1 pending status names")
-        print(ogc.OGC_PENDING_STATUSES)
-        process_name = None
-        if ogc.OGC_PENDING_STATUSES.includes(current_status):
-            process_name = "Pending job completion"
-        else:
-            process_name = get_process_name_from_hysds_name(job_type) if job_type else "Error"
         job_info.update({
             "request": None,
             "message": None,

--- a/api/utils/hysds_util.py
+++ b/api/utils/hysds_util.py
@@ -656,16 +656,12 @@ def get_mozart_jobs_from_query_params(query_params, user):
         return response_body, status.HTTP_500_INTERNAL_SERVER_ERROR
 
 def get_mozart_job(job_id):
-    job_status = mozart_job_status(job_id).get("status")
-    if job_status == "job-completed" or job_status == "job-failed":
-        try:
-            mozart_response = get_mozart_job_info(job_id)
-            result = mozart_response.get("result")
-            return result
-        except Exception as ex:
-            raise ex
-    else:
-        raise Exception("Aborting retrieving information of job because status is {}".format(job_status))
+    try:
+        mozart_response = get_mozart_job_info(job_id)
+        result = mozart_response.get("result")
+        return result
+    except Exception as ex:
+        raise ex
 
 
 def get_mozart_queues():

--- a/api/utils/ogc_translate.py
+++ b/api/utils/ogc_translate.py
@@ -39,8 +39,6 @@ GITLAB_PIPELINE_EVENT_STATUS_MAP = {
  "pending": "accepted"
 }
 
-OGC_PENDING_STATUSES = ["accepted", "running", "offline"]
-
 def get_ogc_status_from_gitlab(gitlab_status):
     return GITLAB_PIPELINE_EVENT_STATUS_MAP.get(gitlab_status)
 

--- a/api/utils/ogc_translate.py
+++ b/api/utils/ogc_translate.py
@@ -39,6 +39,8 @@ GITLAB_PIPELINE_EVENT_STATUS_MAP = {
  "pending": "accepted"
 }
 
+OGC_PENDING_STATUSES = ["accepted", "running", "offline"]
+
 def get_ogc_status_from_gitlab(gitlab_status):
     return GITLAB_PIPELINE_EVENT_STATUS_MAP.get(gitlab_status)
 


### PR DESCRIPTION
I know this could be a significant change for `get_mozart_job` but it is only called by API endpoints for a single job
i.e. never called in a loop for a bunch of jobs 

These are the potential states: 
STATUS_JOB_STARTED = "job-started"
STATUS_JOB_COMPLETED = "job-completed"
STATUS_JOB_QUEUED = "job-queued"
STATUS_JOB_FAILED = "job-failed"
STATUS_JOB_REVOKED = "job-revoked"
STATUS_JOB_DEDUPED = "job-deduped"
STATUS_JOB_OFFLINE = "job-offline" (I couldnt find any offline jobs on DIT and figaro isn't working for me right now, message in maap-dev) 

And I called a job status for a job with all of those states and there are no errors so it seems okay to remove the check that you can only get info for a job that is completed or failed

This was causing a problem for Marjorie because a job in the pending state wouldn't have any information about it since `get_mozart_job` would not return anything 