### PR TITLE
not throwing error when optional input with no default

### DIFF
--- a/api/utils/hysds_util.py
+++ b/api/utils/hysds_util.py
@@ -579,6 +579,7 @@ def validate_job_submit(hysds_io, user_params, username):
         param_name = param.get("name")
         param_info["from"] = param.get("from")
         param_info["default"] = param.get("default", None)
+        param_info["optional"] = param.get("optional", False)
         param_info["type"] = param.get("type", str)
         known_params[param_name] = param_info
 
@@ -597,7 +598,8 @@ def validate_job_submit(hysds_io, user_params, username):
         else:
             if known_params.get(p).get("default") is not None:
                 validated_params[p] = known_params.get(p).get("default")
-            else:
+            # only raise an error when no default and not optional. If optional and no default, don't pass anything
+            elif not known_params.get(p).get("optional"):
                 raise ValueError("Parameter {} missing from inputs. No default set in algorithm spec. Please specify and resubmit.".format(p))
     return validated_params
 


### PR DESCRIPTION
Only raise an error when no default and not optional. If optional and no default, don't pass anything
Also, show optional when listing information about params


I didn't get a reply to this on slack:

> The code was originally written so that the parameter is assigned to it’s input value if it is passed: https://github.com/MAAP-Project/maap-api-nasa/blame/main/api/utils/hysds_util.py#L592
> 
> I.e. the current code
>     "inputs": {
>     }
> will use the default if applicable, if not throw error
> 
> but then
>     "inputs": {
>         "bbox": ""
>     }
> Will pass bbox as an empty string into HySDS even if bbox has a default value 
> 
> Should I change the line to count an empty string as no input (i.e. would use the default if possible)?
> Because for users using the UI, Marjorie could not pass the API the bbox argument if they left it empty
> But technical users could override the default optional problem by passing bbox: “” to use nothing (this might cause problems for the user though if the input can’t be a string like Chuck [said](https://github.com/MAAP-Project/Community/issues/1244#issuecomment-4077416218))

But I think we should keep as is and @marjo-luc should not pass the argument to the API if the user leaves it blank 
If the user is technical and submitting their job from maap-py or the API, they should have the option to override the optional with a default problem by passing an empty string for the argument they actually want to leave empty
Also, we should keep the existing functionality that users have come to know 