### PR TITLE
Validate cwl without saving as a file or using subprocess 

### DIFF
--- a/api/utils/ogc_process_util.py
+++ b/api/utils/ogc_process_util.py
@@ -157,6 +157,9 @@ def get_cwl_metadata(cwl_text, cwl_link=None):
 
         if not validation_result.get('valid', False):
             issues = validation_result.get('issues', [])
+            print("graceal1 printing issues for app validation")
+            print(issues)
+            logging.error(issues)
             error_messages = [issue['message'] for issue in issues if issue['type'] == 'error']
             if error_messages:
                 error_msg = '; '.join(error_messages)

--- a/api/utils/ogc_process_util.py
+++ b/api/utils/ogc_process_util.py
@@ -13,11 +13,9 @@ from datetime import datetime, timezone
 import gitlab
 import requests
 import yaml
-from schema_salad.exceptions import ValidationException
 from cwltool.load_tool import load_tool
 from cwltool.context import LoadingContext
 from cwltool.workflow import default_make_tool
-from cwl_utils.parser import cwl_v1_2
 from flask import current_app
 from flask_api import status
 
@@ -186,7 +184,7 @@ def get_cwl_metadata(cwl_text, cwl_link=None):
 
         # Set up LoadingContext to avoid fetching external files
         loading_context = LoadingContext()
-        loading_context.do_update = False  # Don't update schemas
+        loading_context.do_update = False  # Don't update schemas, this causes unnecessary calls 
         loading_context.disable_js_validation = False  # Keep JS validation
         loading_context.construct_tool_object = default_make_tool  # Use default tool factory
 
@@ -194,16 +192,16 @@ def get_cwl_metadata(cwl_text, cwl_link=None):
         # This validates the structure but we'll extract metadata from our parsed dict
         try:
             load_tool(cwl_dict, loading_context)
-        except ValidationException as val_err:
-            log.error(f"CWL validation failed: {val_err}")
-            raise ValueError(f"CWL validation failed: {str(val_err)}")
+        except Exception as err:
+            log.error(f"CWL validation failed: {err}")
+            raise ValueError(f"CWL validation failed: {str(err)}")
 
         # Extract workflow metadata from the workflow_dict we found
         cwl_id = workflow_dict.get('id', '')
         title = workflow_dict.get('label', '')
         description = workflow_dict.get('doc', '')
 
-        # Extract version from text (schema.org annotation)
+        # Extract version from text 
         version_match = re.search(r"s:version:[ \t]*(\S+)", cwl_text, re.IGNORECASE)
 
         if not version_match or not cwl_id:
@@ -250,24 +248,17 @@ def get_cwl_metadata(cwl_text, cwl_link=None):
 
             # Get the tool reference from the step
             tool_ref = first_step.get('run', {})
+            tool_id = os.path.basename(tool_ref.split('#')[-1]) if isinstance(tool_ref, str) else None
+            command_line_tool = None
 
-            # If tool_ref is a dict, it's an embedded CommandLineTool
-            if isinstance(tool_ref, dict):
-                command_line_tool = tool_ref
-            else:
-                # It's a reference - we need to resolve it from the $graph or loaded tools
-                # For now, we'll search in the original dict for the tool
-                tool_id = os.path.basename(tool_ref.split('#')[-1]) if isinstance(tool_ref, str) else None
-                command_line_tool = None
-
-                # Check if there's a $graph with multiple documents
-                if '$graph' in cwl_dict:
-                    for doc in cwl_dict['$graph']:
-                        if doc.get('class') == 'CommandLineTool':
-                            doc_id = doc.get('id', '')
-                            if tool_id and (doc_id.endswith(tool_id) or doc_id.endswith('#' + tool_id)):
-                                command_line_tool = doc
-                                break
+            # Check if there's a $graph with multiple documents
+            if '$graph' in cwl_dict:
+                for doc in cwl_dict['$graph']:
+                    if doc.get('class') == 'CommandLineTool':
+                        doc_id = doc.get('id', '')
+                        if tool_id and (doc_id.endswith(tool_id) or doc_id.endswith('#' + tool_id)):
+                            command_line_tool = doc
+                            break
 
             if command_line_tool:
                 # Extract baseCommand
@@ -283,9 +274,6 @@ def get_cwl_metadata(cwl_text, cwl_link=None):
     except yaml.YAMLError as e:
         log.error(f"Failed to parse CWL YAML: {e}")
         raise ValueError(f"CWL file is not valid YAML: {str(e)}")
-    except ValidationException as e:
-        log.error(f"CWL validation failed: {e}")
-        raise ValueError(f"CWL validation failed: {str(e)}")
     except Exception as e:
         log.error(f"Failed to parse or validate CWL: {e}")
         raise ValueError(f"CWL file is not in the right format or is invalid: {str(e)}")

--- a/api/utils/ogc_process_util.py
+++ b/api/utils/ogc_process_util.py
@@ -16,6 +16,7 @@ import yaml
 from cwltool.load_tool import load_tool
 from cwltool.context import LoadingContext
 from cwltool.workflow import default_make_tool
+from cwl_utils.parser import load_document_by_string, cwl_v1_2
 from flask import current_app
 from flask_api import status
 
@@ -152,35 +153,15 @@ def get_cwl_metadata(cwl_text, cwl_link=None):
     base_command = None
 
     try:
+        # Check for cwltool errors (i.e. JSX error when NodeJS missing)
         # Parse YAML - use a custom loader to prevent date string conversion
         class NoDatesSafeLoader(yaml.SafeLoader):
             pass
-
-        # Remove timestamp resolver to keep dates as strings
         NoDatesSafeLoader.yaml_implicit_resolvers = {
             k: [r for r in v if r[0] != 'tag:yaml.org,2002:timestamp']
             for k, v in NoDatesSafeLoader.yaml_implicit_resolvers.items()
         }
-
         cwl_dict = yaml.load(cwl_text, Loader=NoDatesSafeLoader)
-
-        # Find the Workflow document in the CWL
-        # CWL files can have a $graph with multiple documents, or be a single document
-        workflow_dict = None
-
-        if '$graph' in cwl_dict:
-            # Multiple documents - find the Workflow
-            for doc in cwl_dict['$graph']:
-                if doc.get('class') == 'Workflow':
-                    workflow_dict = doc
-                    break
-            if not workflow_dict:
-                raise ValueError("A valid Workflow object must be defined in the CWL file.")
-        elif cwl_dict.get('class') == 'Workflow':
-            # Single document that is a Workflow
-            workflow_dict = cwl_dict
-        else:
-            raise ValueError("A valid Workflow object must be defined in the CWL file.")
 
         # Set up LoadingContext to avoid fetching external files
         loading_context = LoadingContext()
@@ -188,27 +169,39 @@ def get_cwl_metadata(cwl_text, cwl_link=None):
         loading_context.disable_js_validation = False  # Keep JS validation
         loading_context.construct_tool_object = default_make_tool  # Use default tool factory
 
-        # Validate the entire CWL document with load_tool
-        # This validates the structure but we'll extract metadata from our parsed dict
+        uri = cwl_link if cwl_link else "api://user-submitted-raw-text.cwl"
+
+        # Validate the entire CWL document (load_tool is what catches JSX errors)
         try:
             load_tool(cwl_dict, loading_context)
+            cwl_obj = load_document_by_string(cwl_text, uri=uri, load_all=True)
         except Exception as err:
             log.error(f"CWL validation failed: {err}")
             raise ValueError(f"CWL validation failed: {str(err)}")
+        
+        # Now parse the CWL document for relevant metadata and throw errors if required fields missing
+        # Ensure cwl_obj is iterable (should be a list when load_all=True)
+        try:
+            cwl_obj = list(cwl_obj) if hasattr(cwl_obj, '__iter__') and not isinstance(cwl_obj, str) else [cwl_obj]
+        except TypeError:
+            raise ValueError("CWL file structure is invalid: unable to parse CWL document.")
 
-        # Extract workflow metadata from the workflow_dict we found
-        cwl_id = workflow_dict.get('id', '')
-        title = workflow_dict.get('label', '')
-        description = workflow_dict.get('doc', '')
+        workflow = next((obj for obj in cwl_obj if isinstance(obj, cwl_v1_2.Workflow)), None)
+        if not workflow:
+            raise ValueError("A valid Workflow object must be defined in the CWL file.")
 
-        # Extract version from text 
+        cwl_id = workflow.id
         version_match = re.search(r"s:version:[ \t]*(\S+)", cwl_text, re.IGNORECASE)
-
+        
         if not version_match or not cwl_id:
             raise ValueError("Required metadata missing: s:version and a top-level id are required.")
 
         fragment = urllib.parse.urlparse(cwl_id).fragment
-        cwl_id = os.path.basename(fragment) if fragment else os.path.basename(cwl_id)
+        cwl_id = os.path.basename(fragment)
+        print("graceal1 cwl_id is ")
+        print(cwl_id)
+        logging.error("graceal1 cwl id is ")
+        logging.error(cwl_id)
         process_version = version_match.group(1).strip().strip("'\"")
 
         if not process_version:
@@ -238,42 +231,27 @@ def get_cwl_metadata(cwl_text, cwl_link=None):
             log.error(f"Failed to get author name: {e}")
 
         # Find the CommandLineTool run by the first step of the workflow
-        workflow_steps = workflow_dict.get('steps', [])
-        if workflow_steps:
-            # Get the first step - could be a list or dict
-            if isinstance(workflow_steps, list):
-                first_step = workflow_steps[0]
-            else:
-                first_step = list(workflow_steps.values())[0]
+        if workflow.steps:
+            # Get the ID of the tool to run (e.g., '#main')
+            tool_id_ref = workflow.steps[0].run
+            # The actual ID is the part after the '#'
+            tool_id = os.path.basename(tool_id_ref)
 
-            # Get the tool reference from the step
-            tool_ref = first_step.get('run', {})
-            tool_id = os.path.basename(tool_ref.split('#')[-1]) if isinstance(tool_ref, str) else None
-            command_line_tool = None
-
-            # Check if there's a $graph with multiple documents
-            if '$graph' in cwl_dict:
-                for doc in cwl_dict['$graph']:
-                    if doc.get('class') == 'CommandLineTool':
-                        doc_id = doc.get('id', '')
-                        if tool_id and (doc_id.endswith(tool_id) or doc_id.endswith('#' + tool_id)):
-                            command_line_tool = doc
-                            break
-
+            # Find the CommandLineTool object in the parsed CWL graph
+            command_line_tool = next((obj for obj in cwl_obj if isinstance(obj, cwl_v1_2.CommandLineTool) and obj.id.endswith(tool_id)), None)
+        
             if command_line_tool:
-                # Extract baseCommand
-                base_command = command_line_tool.get('baseCommand')
+                # Extract the baseCommand directly
+                base_command = command_line_tool.baseCommand
+        
+                # Find the ResourceRequirement to extract ramMin and coresMin
+                if command_line_tool.requirements:
+                    for req in command_line_tool.requirements:
+                        if isinstance(req, cwl_v1_2.ResourceRequirement):
+                            ram_min = req.ramMin if req.ramMin else ram_min
+                            cores_min = req.coresMin if req.coresMin else cores_min
+                            break  # Stop after finding the first ResourceRequirement
 
-                # Find ResourceRequirement
-                requirements = command_line_tool.get('requirements', [])
-                resource_reqs = requirements.get('ResourceRequirement')
-                if resource_reqs:
-                    ram_min = resource_reqs.get('ramMin')
-                    cores_min = resource_reqs.get('coresMin')
-
-    except yaml.YAMLError as e:
-        log.error(f"Failed to parse CWL YAML: {e}")
-        raise ValueError(f"CWL file is not valid YAML: {str(e)}")
     except Exception as e:
         log.error(f"Failed to parse or validate CWL: {e}")
         raise ValueError(f"CWL file is not in the right format or is invalid: {str(e)}")
@@ -281,8 +259,8 @@ def get_cwl_metadata(cwl_text, cwl_link=None):
     return CWL_METADATA(
         id=cwl_id,
         version=process_version,
-        title=title,
-        description=description,
+        title=workflow.label,
+        description=workflow.doc,
         keywords=keywords,
         raw_text=cwl_text,
         github_url=github_url,

--- a/api/utils/ogc_process_util.py
+++ b/api/utils/ogc_process_util.py
@@ -189,7 +189,6 @@ def get_cwl_metadata(cwl_text, cwl_link=None):
         loading_context.do_update = False  # Don't update schemas
         loading_context.disable_js_validation = False  # Keep JS validation
         loading_context.construct_tool_object = default_make_tool  # Use default tool factory
-        loading_context.fetcher_constructor = None  # Don't fetch external schemas
 
         # Validate the entire CWL document with load_tool
         # This validates the structure but we'll extract metadata from our parsed dict
@@ -276,11 +275,10 @@ def get_cwl_metadata(cwl_text, cwl_link=None):
 
                 # Find ResourceRequirement
                 requirements = command_line_tool.get('requirements', [])
-                for req in requirements:
-                    if req.get('class') == 'ResourceRequirement':
-                        ram_min = req.get('ramMin')
-                        cores_min = req.get('coresMin')
-                        break
+                resource_reqs = requirements.get('ResourceRequirement')
+                if resource_reqs:
+                    ram_min = resource_reqs.get('ramMin')
+                    cores_min = resource_reqs.get('coresMin')
 
     except yaml.YAMLError as e:
         log.error(f"Failed to parse CWL YAML: {e}")

--- a/api/utils/ogc_process_util.py
+++ b/api/utils/ogc_process_util.py
@@ -6,7 +6,6 @@ Shared between OGC and build endpoints to avoid code duplication.
 import logging
 import os
 import re
-import subprocess
 import tempfile
 import urllib.parse
 from collections import namedtuple
@@ -15,6 +14,9 @@ from datetime import datetime, timezone
 import gitlab
 import requests
 from cwl_utils.parser import load_document_by_uri, cwl_v1_2
+from cwltool.load_tool import load_tool
+from cwltool.context import LoadingContext
+from ap_validator import validate_cwl
 from flask import current_app
 from flask_api import status
 
@@ -160,28 +162,34 @@ def get_cwl_metadata(cwl_text, cwl_link=None):
             tmp.write(cwl_text)
             tmp_path = tmp.name
 
-        # Validate with cwltool
-        result = subprocess.run(
-            ["cwltool", "--validate", tmp_path],
-            capture_output=True, text=True
-        )
-        if result.returncode != 0:
-            raise ValueError(f"CWL validation failed: {result.stderr.strip()}")
+        # Validate with cwltool using Python API
+        try:
+            # Create loading context and enable validation
+            loading_context = LoadingContext()
+            loading_context.do_validate = True
 
-        # Validate with ap-validator
-        ap_result = subprocess.run(
-            ["ap-validator", tmp_path],
-            capture_output=True, text=True
-        )
-        if ap_result.returncode != 0:
-            raise ValueError(f"Application Package validation failed: {ap_result.stderr.strip()}")
+            # load_tool performs validation when do_validate is True
+            load_tool(tmp_path, loading_context)
+        except Exception as e:
+            raise ValueError(f"CWL validation failed: {str(e)}")
+
+        # Validate with ap-validator using Python API
+        try:
+            validation_result = validate_cwl(tmp_path)
+            if not validation_result.get('valid', False):
+                errors = validation_result.get('errors', ['Unknown validation error'])
+                error_msg = '; '.join(str(err) for err in errors)
+                raise ValueError(f"Application Package validation failed: {error_msg}")
+        except ValueError:
+            # Re-raise ValueError from validation failures
+            raise
+        except Exception as e:
+            raise ValueError(f"Application Package validation failed: {str(e)}")
 
         cwl_obj = load_document_by_uri(urllib.parse.urlparse(tmp_path).geturl(), load_all=True)
 
     except FileNotFoundError as e:
-        if "cwltool" in str(e) or "ap-validator" in str(e):
-            raise ValueError("cwltool or ap-validator is not installed or not found on PATH.")
-        raise ValueError("cwltool or ap-validator is not installed or not found on PATH.")
+        raise ValueError(f"Required file not found: {str(e)}")
     except Exception as e:
         log.error(f"Failed to parse CWL: {e}")
         raise ValueError("CWL file is not in the right format or is invalid.")

--- a/api/utils/ogc_process_util.py
+++ b/api/utils/ogc_process_util.py
@@ -6,17 +6,14 @@ Shared between OGC and build endpoints to avoid code duplication.
 import logging
 import os
 import re
-import tempfile
 import urllib.parse
 from collections import namedtuple
 from datetime import datetime, timezone
 
 import gitlab
 import requests
-from cwl_utils.parser import load_document_by_uri, cwl_v1_2
-from cwltool.load_tool import load_tool
-from cwltool.context import LoadingContext
-from ap_validator import validate_cwl
+from cwl_utils.parser import cwl_v1_2
+from ap_validator.app_package import AppPackage
 from flask import current_app
 from flask_api import status
 
@@ -153,49 +150,29 @@ def get_cwl_metadata(cwl_text, cwl_link=None):
     base_command = None
     
     try:
-        # 1. Save the contents of cwl_text to a temporary file.
-        # 2. Use the local file URI with cwl_utils to parse the object model.
-        # 3. Use the in-memory text for regex-based metadata extraction.
-        # This is wrapped in a try/finally block to ensure the temp file is cleaned up.
+        # Validate with ap-validator using Python API (works with in-memory string)
+        # Note: ap-validator internally runs cwltool validation first, then checks OGC requirements
+        app_package = AppPackage.from_string(cwl_text)
+        validation_result = app_package.check_all(include=["error", "hint"])
 
-        with tempfile.NamedTemporaryFile(mode='w', suffix=".cwl", delete=False) as tmp:
-            tmp.write(cwl_text)
-            tmp_path = tmp.name
-
-        # Validate with cwltool using Python API
-        try:
-            # Create loading context and enable validation
-            loading_context = LoadingContext()
-            loading_context.do_validate = True
-
-            # load_tool performs validation when do_validate is True
-            load_tool(tmp_path, loading_context)
-        except Exception as e:
-            raise ValueError(f"CWL validation failed: {str(e)}")
-
-        # Validate with ap-validator using Python API
-        try:
-            validation_result = validate_cwl(tmp_path)
-            if not validation_result.get('valid', False):
-                errors = validation_result.get('errors', ['Unknown validation error'])
-                error_msg = '; '.join(str(err) for err in errors)
+        if not validation_result.get('valid', False):
+            issues = validation_result.get('issues', [])
+            error_messages = [issue['message'] for issue in issues if issue['type'] == 'error']
+            if error_messages:
+                error_msg = '; '.join(error_messages)
                 raise ValueError(f"Application Package validation failed: {error_msg}")
-        except ValueError:
-            # Re-raise ValueError from validation failures
-            raise
-        except Exception as e:
-            raise ValueError(f"Application Package validation failed: {str(e)}")
+            else:
+                raise ValueError("Application Package validation failed with unknown errors")
 
-        cwl_obj = load_document_by_uri(urllib.parse.urlparse(tmp_path).geturl(), load_all=True)
+        # Parse CWL object model (already loaded by AppPackage)
+        cwl_obj = app_package.cwl_obj
 
-    except FileNotFoundError as e:
-        raise ValueError(f"Required file not found: {str(e)}")
+    except ValueError:
+        # Re-raise ValueError from validation failures
+        raise
     except Exception as e:
-        log.error(f"Failed to parse CWL: {e}")
-        raise ValueError("CWL file is not in the right format or is invalid.")
-    finally:
-        if 'tmp_path' in locals() and os.path.exists(tmp_path):
-            os.remove(tmp_path)
+        log.error(f"Failed to parse or validate CWL: {e}")
+        raise ValueError(f"CWL file is not in the right format or is invalid: {str(e)}")
 
     # Ensure cwl_obj is iterable (should be a list when load_all=True)
     try:

--- a/api/utils/ogc_process_util.py
+++ b/api/utils/ogc_process_util.py
@@ -9,9 +9,14 @@ import re
 import urllib.parse
 from collections import namedtuple
 from datetime import datetime, timezone
+from contextlib import redirect_stderr
+from io import StringIO
 
 import gitlab
 import requests
+import yaml
+from schema_salad.exceptions import ValidationException
+from cwltool.process import shortname
 from cwl_utils.parser import cwl_v1_2
 from ap_validator.app_package import AppPackage
 from flask import current_app
@@ -32,6 +37,112 @@ DEPLOYED_PROCESS_STATUS = "deployed"
 UNDEPLOYED_PROCESS_STATUS = "undeployed"
 HREF_LANG = "en"
 ERROR_TYPE_PREFIX = "http://www.opengis.net/def/exceptions/"
+
+
+def validate_cwl_with_detailed_errors(cwl_text):
+    """
+    Use ap-validator but capture all error details including cwltool errors.
+
+    This captures stderr and logging to get detailed error messages that don't appear
+    in the validation_result (e.g., JavaScript/Node.js engine errors).
+
+    Args:
+        cwl_text (str): Raw CWL text to validate
+
+    Returns:
+        tuple: (is_valid: bool, app_package: AppPackage or None, error_details: str or None)
+    """
+    # Buffers for capturing output
+    stderr_buffer = StringIO()
+    log_buffer = StringIO()
+
+    # Create a temporary handler for cwltool logger
+    log_handler = logging.StreamHandler(log_buffer)
+    log_handler.setLevel(logging.ERROR)  # Only capture ERROR and above for efficiency
+
+    # Get cwltool logger and save original state
+    cwltool_logger = logging.getLogger('cwltool')
+    original_level = cwltool_logger.level
+    cwltool_logger.addHandler(log_handler)
+    cwltool_logger.setLevel(logging.ERROR)
+
+    try:
+        # Use context manager for thread-safer stderr redirection
+        with redirect_stderr(stderr_buffer):
+            # Validate with ap-validator
+            app_package = AppPackage.from_string(cwl_text)
+            validation_result = app_package.check_all(include=["error"])
+
+        is_valid = validation_result.get('valid', False)
+
+        if not is_valid:
+            # Build error message from multiple sources
+            error_parts = []
+
+            # 1. Get issues from validation result
+            issues = validation_result.get('issues', [])
+            error_issues = [i['message'].strip() for i in issues
+                          if i.get('type') == 'error' and i.get('message', '').strip()]
+
+            if error_issues:
+                error_parts.append("Validation errors:\n" + "\n".join(f"- {msg}" for msg in error_issues))
+
+            # 2. Get stderr output (often contains critical error details)
+            stderr_content = stderr_buffer.getvalue().strip()
+            if stderr_content:
+                error_parts.append(f"Details: {stderr_content}")
+
+            # 3. Get log output (contains JavaScript/Node.js errors, etc.)
+            log_content = log_buffer.getvalue().strip()
+            if log_content:
+                # Filter out noise - only keep lines with actual error info
+                log_lines = [line for line in log_content.split('\n')
+                           if any(keyword in line.lower()
+                                for keyword in ['error', 'failed', "couldn't", 'requires', 'missing'])]
+                if log_lines:
+                    error_parts.append("Error details:\n" + "\n".join(log_lines))
+
+            full_error = "\n\n".join(error_parts) if error_parts else "CWL validation failed"
+            return False, None, full_error
+
+        return True, app_package, None
+
+    except ValidationException as e:
+        # Validation exception with captured output
+        error_msg = f"ValidationException: {str(e)}"
+        stderr_content = stderr_buffer.getvalue().strip()
+        log_content = log_buffer.getvalue().strip()
+
+        if stderr_content or log_content:
+            details = []
+            if stderr_content:
+                details.append(stderr_content)
+            if log_content:
+                details.append(log_content)
+            error_msg += "\n" + "\n".join(details)
+
+        return False, None, error_msg
+
+    except Exception as e:
+        # Generic exception with captured output
+        error_msg = f"CWL validation error: {str(e)}"
+        stderr_content = stderr_buffer.getvalue().strip()
+        log_content = log_buffer.getvalue().strip()
+
+        if stderr_content or log_content:
+            details = []
+            if stderr_content:
+                details.append(stderr_content)
+            if log_content:
+                details.append(log_content)
+            error_msg += "\n" + "\n".join(details)
+
+        return False, None, error_msg
+
+    finally:
+        # Always clean up logging handler
+        cwltool_logger.removeHandler(log_handler)
+        cwltool_logger.setLevel(original_level)
 
 
 def get_hysds_process_name(id, user_id, version):
@@ -150,24 +261,19 @@ def get_cwl_metadata(cwl_text, cwl_link=None):
     base_command = None
     
     try:
-        # Validate with ap-validator using Python API (works with in-memory string)
+        # Validate with ap-validator using Python API with detailed error capture
         # Note: ap-validator internally runs cwltool validation first, then checks OGC requirements
-        app_package = AppPackage.from_string(cwl_text)
-        validation_result = app_package.check_all(include=["error", "hint"])
+        is_valid, app_package, error_details = validate_cwl_with_detailed_errors(cwl_text)
 
-        if not validation_result.get('valid', False):
-            issues = validation_result.get('issues', [])
-            print("graceal1 printing issues for app validation")
-            print(issues)
-            logging.error(issues)
-            error_messages = [issue['message'] for issue in issues if issue['type'] == 'error']
-            if error_messages:
-                error_msg = '; '.join(error_messages)
-                raise ValueError(f"Application Package validation failed: {error_msg}")
+        if not is_valid:
+            # Raise ValueError with detailed error message
+            if error_details:
+                log.error(f"CWL validation failed: {error_details}")
+                raise ValueError(error_details)
             else:
-                raise ValueError("Application Package validation failed with unknown errors")
+                raise ValueError("CWL validation failed with unknown errors")
 
-        # Parse CWL object model (already loaded by AppPackage)
+        # Parse CWL object model (already loaded by AppPackage during validation)
         cwl_obj = app_package.cwl_obj
 
     except ValueError:

--- a/api/utils/ogc_process_util.py
+++ b/api/utils/ogc_process_util.py
@@ -14,9 +14,9 @@ import gitlab
 import requests
 import yaml
 from schema_salad.exceptions import ValidationException
-from cwltool.process import shortname
 from cwltool.load_tool import load_tool
 from cwltool.context import LoadingContext
+from cwltool.workflow import default_make_tool
 from cwl_utils.parser import cwl_v1_2
 from flask import current_app
 from flask_api import status
@@ -154,19 +154,133 @@ def get_cwl_metadata(cwl_text, cwl_link=None):
     base_command = None
 
     try:
-        # Parse YAML
-        cwl_dict = yaml.safe_load(cwl_text)
+        # Parse YAML - use a custom loader to prevent date string conversion
+        class NoDatesSafeLoader(yaml.SafeLoader):
+            pass
 
-        # Validate using cwltool's load_tool - this validates and provides detailed errors
+        # Remove timestamp resolver to keep dates as strings
+        NoDatesSafeLoader.yaml_implicit_resolvers = {
+            k: [r for r in v if r[0] != 'tag:yaml.org,2002:timestamp']
+            for k, v in NoDatesSafeLoader.yaml_implicit_resolvers.items()
+        }
+
+        cwl_dict = yaml.load(cwl_text, Loader=NoDatesSafeLoader)
+
+        # Find the Workflow document in the CWL
+        # CWL files can have a $graph with multiple documents, or be a single document
+        workflow_dict = None
+
+        if '$graph' in cwl_dict:
+            # Multiple documents - find the Workflow
+            for doc in cwl_dict['$graph']:
+                if doc.get('class') == 'Workflow':
+                    workflow_dict = doc
+                    break
+            if not workflow_dict:
+                raise ValueError("A valid Workflow object must be defined in the CWL file.")
+        elif cwl_dict.get('class') == 'Workflow':
+            # Single document that is a Workflow
+            workflow_dict = cwl_dict
+        else:
+            raise ValueError("A valid Workflow object must be defined in the CWL file.")
+
+        # Set up LoadingContext to avoid fetching external files
         loading_context = LoadingContext()
-        loading_context.do_validate = True
-        loading_context.strict = True
+        loading_context.do_update = False  # Don't update schemas
+        loading_context.disable_js_validation = False  # Keep JS validation
+        loading_context.construct_tool_object = default_make_tool  # Use default tool factory
+        loading_context.fetcher_constructor = None  # Don't fetch external schemas
 
-        # This will raise ValidationException with detailed error messages if invalid
-        load_tool(cwl_dict, loading_context)
+        # Validate the entire CWL document with load_tool
+        # This validates the structure but we'll extract metadata from our parsed dict
+        try:
+            load_tool(cwl_dict, loading_context)
+        except ValidationException as val_err:
+            log.error(f"CWL validation failed: {val_err}")
+            raise ValueError(f"CWL validation failed: {str(val_err)}")
 
-        # Parse CWL object model using cwl_utils
-        cwl_obj = cwl_v1_2.load_document_by_yaml(cwl_dict, cwl_link or "file:///cwl")
+        # Extract workflow metadata from the workflow_dict we found
+        cwl_id = workflow_dict.get('id', '')
+        title = workflow_dict.get('label', '')
+        description = workflow_dict.get('doc', '')
+
+        # Extract version from text (schema.org annotation)
+        version_match = re.search(r"s:version:[ \t]*(\S+)", cwl_text, re.IGNORECASE)
+
+        if not version_match or not cwl_id:
+            raise ValueError("Required metadata missing: s:version and a top-level id are required.")
+
+        fragment = urllib.parse.urlparse(cwl_id).fragment
+        cwl_id = os.path.basename(fragment) if fragment else os.path.basename(cwl_id)
+        process_version = version_match.group(1).strip().strip("'\"")
+
+        if not process_version:
+            raise ValueError("Required metadata missing: s:version must have a non-empty value.")
+
+        if ":" in process_version:
+            raise ValueError("Process version cannot contain a :")
+
+        # Get git information
+        github_url = re.search(r"s:codeRepository:\s*(\S+)", cwl_text, re.IGNORECASE)
+        github_url = github_url.group(1) if github_url else None
+        git_commit_hash = re.search(r"s:commitHash:\s*(\S+)", cwl_text, re.IGNORECASE)
+        git_commit_hash = git_commit_hash.group(1) if git_commit_hash else None
+
+        keywords_match = re.search(r"s:keywords:\s*(.*)", cwl_text, re.IGNORECASE)
+        keywords = keywords_match.group(1).replace(" ", "") if keywords_match else None
+
+        try:
+            author_match = re.search(
+                r"s:author:.*?s:name:\s*(\S+)",
+                cwl_text,
+                re.DOTALL | re.IGNORECASE
+            )
+            author = author_match.group(1) if author_match else None
+        except Exception as e:
+            author = None
+            log.error(f"Failed to get author name: {e}")
+
+        # Find the CommandLineTool run by the first step of the workflow
+        workflow_steps = workflow_dict.get('steps', [])
+        if workflow_steps:
+            # Get the first step - could be a list or dict
+            if isinstance(workflow_steps, list):
+                first_step = workflow_steps[0]
+            else:
+                first_step = list(workflow_steps.values())[0]
+
+            # Get the tool reference from the step
+            tool_ref = first_step.get('run', {})
+
+            # If tool_ref is a dict, it's an embedded CommandLineTool
+            if isinstance(tool_ref, dict):
+                command_line_tool = tool_ref
+            else:
+                # It's a reference - we need to resolve it from the $graph or loaded tools
+                # For now, we'll search in the original dict for the tool
+                tool_id = os.path.basename(tool_ref.split('#')[-1]) if isinstance(tool_ref, str) else None
+                command_line_tool = None
+
+                # Check if there's a $graph with multiple documents
+                if '$graph' in cwl_dict:
+                    for doc in cwl_dict['$graph']:
+                        if doc.get('class') == 'CommandLineTool':
+                            doc_id = doc.get('id', '')
+                            if tool_id and (doc_id.endswith(tool_id) or doc_id.endswith('#' + tool_id)):
+                                command_line_tool = doc
+                                break
+
+            if command_line_tool:
+                # Extract baseCommand
+                base_command = command_line_tool.get('baseCommand')
+
+                # Find ResourceRequirement
+                requirements = command_line_tool.get('requirements', [])
+                for req in requirements:
+                    if req.get('class') == 'ResourceRequirement':
+                        ram_min = req.get('ramMin')
+                        cores_min = req.get('coresMin')
+                        break
 
     except yaml.YAMLError as e:
         log.error(f"Failed to parse CWL YAML: {e}")
@@ -178,79 +292,11 @@ def get_cwl_metadata(cwl_text, cwl_link=None):
         log.error(f"Failed to parse or validate CWL: {e}")
         raise ValueError(f"CWL file is not in the right format or is invalid: {str(e)}")
 
-    # Ensure cwl_obj is iterable (should be a list when load_all=True)
-    try:
-        cwl_obj = list(cwl_obj) if hasattr(cwl_obj, '__iter__') and not isinstance(cwl_obj, str) else [cwl_obj]
-    except TypeError:
-        raise ValueError("CWL file structure is invalid: unable to parse CWL document.")
-
-    workflow = next((obj for obj in cwl_obj if isinstance(obj, cwl_v1_2.Workflow)), None)
-    if not workflow:
-        raise ValueError("A valid Workflow object must be defined in the CWL file.")
-
-    cwl_id = workflow.id
-    version_match = re.search(r"s:version:[ \t]*(\S+)", cwl_text, re.IGNORECASE)
-    
-    if not version_match or not cwl_id:
-        raise ValueError("Required metadata missing: s:version and a top-level id are required.")
-
-    fragment = urllib.parse.urlparse(cwl_id).fragment
-    cwl_id = os.path.basename(fragment)
-    process_version = version_match.group(1).strip().strip("'\"")
-
-    if not process_version:
-        raise ValueError("Required metadata missing: s:version must have a non-empty value.")
-
-    if ":" in process_version:
-        raise ValueError("Process version cannot contain a :")
-
-    # Get git information
-    github_url = re.search(r"s:codeRepository:\s*(\S+)", cwl_text, re.IGNORECASE)
-    github_url = github_url.group(1) if github_url else None
-    git_commit_hash = re.search(r"s:commitHash:\s*(\S+)", cwl_text, re.IGNORECASE)
-    git_commit_hash = git_commit_hash.group(1) if git_commit_hash else None
-
-    keywords_match = re.search(r"s:keywords:\s*(.*)", cwl_text, re.IGNORECASE)
-    keywords = keywords_match.group(1).replace(" ", "") if keywords_match else None
-
-    try:
-        author_match = re.search(
-            r"s:author:.*?s:name:\s*(\S+)",
-            cwl_text,
-            re.DOTALL | re.IGNORECASE
-        )
-        author = author_match.group(1) if author_match else None
-    except Exception as e:
-        author = None
-        log.error(f"Failed to get author name: {e}")
-
-    # Find the CommandLineTool run by the first step of the workflow
-    if workflow.steps:
-        # Get the ID of the tool to run (e.g., '#main')
-        tool_id_ref = workflow.steps[0].run
-        # The actual ID is the part after the '#'
-        tool_id = os.path.basename(tool_id_ref)
-
-        # Find the CommandLineTool object in the parsed CWL graph
-        command_line_tool = next((obj for obj in cwl_obj if isinstance(obj, cwl_v1_2.CommandLineTool) and obj.id.endswith(tool_id)), None)
-    
-        if command_line_tool:
-            # Extract the baseCommand directly
-            base_command = command_line_tool.baseCommand
-    
-            # Find the ResourceRequirement to extract ramMin and coresMin
-            if command_line_tool.requirements:
-                for req in command_line_tool.requirements:
-                    if isinstance(req, cwl_v1_2.ResourceRequirement):
-                        ram_min = req.ramMin if req.ramMin else ram_min
-                        cores_min = req.coresMin if req.coresMin else cores_min
-                        break  # Stop after finding the first ResourceRequirement
-
     return CWL_METADATA(
         id=cwl_id,
         version=process_version,
-        title=workflow.label,
-        description=workflow.doc,
+        title=title,
+        description=description,
         keywords=keywords,
         raw_text=cwl_text,
         github_url=github_url,

--- a/api/utils/ogc_process_util.py
+++ b/api/utils/ogc_process_util.py
@@ -9,16 +9,15 @@ import re
 import urllib.parse
 from collections import namedtuple
 from datetime import datetime, timezone
-from contextlib import redirect_stderr
-from io import StringIO
 
 import gitlab
 import requests
 import yaml
 from schema_salad.exceptions import ValidationException
 from cwltool.process import shortname
+from cwltool.load_tool import load_tool
+from cwltool.context import LoadingContext
 from cwl_utils.parser import cwl_v1_2
-from ap_validator.app_package import AppPackage
 from flask import current_app
 from flask_api import status
 
@@ -37,112 +36,6 @@ DEPLOYED_PROCESS_STATUS = "deployed"
 UNDEPLOYED_PROCESS_STATUS = "undeployed"
 HREF_LANG = "en"
 ERROR_TYPE_PREFIX = "http://www.opengis.net/def/exceptions/"
-
-
-def validate_cwl_with_detailed_errors(cwl_text):
-    """
-    Use ap-validator but capture all error details including cwltool errors.
-
-    This captures stderr and logging to get detailed error messages that don't appear
-    in the validation_result (e.g., JavaScript/Node.js engine errors).
-
-    Args:
-        cwl_text (str): Raw CWL text to validate
-
-    Returns:
-        tuple: (is_valid: bool, app_package: AppPackage or None, error_details: str or None)
-    """
-    # Buffers for capturing output
-    stderr_buffer = StringIO()
-    log_buffer = StringIO()
-
-    # Create a temporary handler for cwltool logger
-    log_handler = logging.StreamHandler(log_buffer)
-    log_handler.setLevel(logging.ERROR)  # Only capture ERROR and above for efficiency
-
-    # Get cwltool logger and save original state
-    cwltool_logger = logging.getLogger('cwltool')
-    original_level = cwltool_logger.level
-    cwltool_logger.addHandler(log_handler)
-    cwltool_logger.setLevel(logging.ERROR)
-
-    try:
-        # Use context manager for thread-safer stderr redirection
-        with redirect_stderr(stderr_buffer):
-            # Validate with ap-validator
-            app_package = AppPackage.from_string(cwl_text)
-            validation_result = app_package.check_all(include=["error"])
-
-        is_valid = validation_result.get('valid', False)
-
-        if not is_valid:
-            # Build error message from multiple sources
-            error_parts = []
-
-            # 1. Get issues from validation result
-            issues = validation_result.get('issues', [])
-            error_issues = [i['message'].strip() for i in issues
-                          if i.get('type') == 'error' and i.get('message', '').strip()]
-
-            if error_issues:
-                error_parts.append("Validation errors:\n" + "\n".join(f"- {msg}" for msg in error_issues))
-
-            # 2. Get stderr output (often contains critical error details)
-            stderr_content = stderr_buffer.getvalue().strip()
-            if stderr_content:
-                error_parts.append(f"Details: {stderr_content}")
-
-            # 3. Get log output (contains JavaScript/Node.js errors, etc.)
-            log_content = log_buffer.getvalue().strip()
-            if log_content:
-                # Filter out noise - only keep lines with actual error info
-                log_lines = [line for line in log_content.split('\n')
-                           if any(keyword in line.lower()
-                                for keyword in ['error', 'failed', "couldn't", 'requires', 'missing'])]
-                if log_lines:
-                    error_parts.append("Error details:\n" + "\n".join(log_lines))
-
-            full_error = "\n\n".join(error_parts) if error_parts else "CWL validation failed"
-            return False, None, full_error
-
-        return True, app_package, None
-
-    except ValidationException as e:
-        # Validation exception with captured output
-        error_msg = f"ValidationException: {str(e)}"
-        stderr_content = stderr_buffer.getvalue().strip()
-        log_content = log_buffer.getvalue().strip()
-
-        if stderr_content or log_content:
-            details = []
-            if stderr_content:
-                details.append(stderr_content)
-            if log_content:
-                details.append(log_content)
-            error_msg += "\n" + "\n".join(details)
-
-        return False, None, error_msg
-
-    except Exception as e:
-        # Generic exception with captured output
-        error_msg = f"CWL validation error: {str(e)}"
-        stderr_content = stderr_buffer.getvalue().strip()
-        log_content = log_buffer.getvalue().strip()
-
-        if stderr_content or log_content:
-            details = []
-            if stderr_content:
-                details.append(stderr_content)
-            if log_content:
-                details.append(log_content)
-            error_msg += "\n" + "\n".join(details)
-
-        return False, None, error_msg
-
-    finally:
-        # Always clean up logging handler
-        cwltool_logger.removeHandler(log_handler)
-        cwltool_logger.setLevel(original_level)
 
 
 def get_hysds_process_name(id, user_id, version):
@@ -259,26 +152,28 @@ def get_cwl_metadata(cwl_text, cwl_link=None):
     ram_min = None
     cores_min = None
     base_command = None
-    
+
     try:
-        # Validate with ap-validator using Python API with detailed error capture
-        # Note: ap-validator internally runs cwltool validation first, then checks OGC requirements
-        is_valid, app_package, error_details = validate_cwl_with_detailed_errors(cwl_text)
+        # Parse YAML
+        cwl_dict = yaml.safe_load(cwl_text)
 
-        if not is_valid:
-            # Raise ValueError with detailed error message
-            if error_details:
-                log.error(f"CWL validation failed: {error_details}")
-                raise ValueError(error_details)
-            else:
-                raise ValueError("CWL validation failed with unknown errors")
+        # Validate using cwltool's load_tool - this validates and provides detailed errors
+        loading_context = LoadingContext()
+        loading_context.do_validate = True
+        loading_context.strict = True
 
-        # Parse CWL object model (already loaded by AppPackage during validation)
-        cwl_obj = app_package.cwl_obj
+        # This will raise ValidationException with detailed error messages if invalid
+        load_tool(cwl_dict, loading_context)
 
-    except ValueError:
-        # Re-raise ValueError from validation failures
-        raise
+        # Parse CWL object model using cwl_utils
+        cwl_obj = cwl_v1_2.load_document_by_yaml(cwl_dict, cwl_link or "file:///cwl")
+
+    except yaml.YAMLError as e:
+        log.error(f"Failed to parse CWL YAML: {e}")
+        raise ValueError(f"CWL file is not valid YAML: {str(e)}")
+    except ValidationException as e:
+        log.error(f"CWL validation failed: {e}")
+        raise ValueError(f"CWL validation failed: {str(e)}")
     except Exception as e:
         log.error(f"Failed to parse or validate CWL: {e}")
         raise ValueError(f"CWL file is not in the right format or is invalid: {str(e)}")

--- a/api/utils/ogc_process_util.py
+++ b/api/utils/ogc_process_util.py
@@ -12,11 +12,11 @@ from datetime import datetime, timezone
 
 import gitlab
 import requests
+from cwl_utils.parser import load_document_by_string, cwl_v1_2
 import yaml
 from cwltool.load_tool import load_tool
 from cwltool.context import LoadingContext
 from cwltool.workflow import default_make_tool
-from cwl_utils.parser import load_document_by_string, cwl_v1_2
 from flask import current_app
 from flask_api import status
 
@@ -152,109 +152,100 @@ def get_cwl_metadata(cwl_text, cwl_link=None):
     cores_min = None
     base_command = None
 
+    # Check for cwltool errors (i.e. JSX error when NodeJS missing)
+    # Parse YAML - use a custom loader to prevent date string conversion
+    class NoDatesSafeLoader(yaml.SafeLoader):
+        pass
+    NoDatesSafeLoader.yaml_implicit_resolvers = {
+        k: [r for r in v if r[0] != 'tag:yaml.org,2002:timestamp']
+        for k, v in NoDatesSafeLoader.yaml_implicit_resolvers.items()
+    }
+
+    # Set up LoadingContext to avoid fetching external files
+    loading_context = LoadingContext()
+    loading_context.do_update = False  # Don't update schemas, this causes unnecessary calls 
+    loading_context.disable_js_validation = False  # Keep JS validation
+    loading_context.construct_tool_object = default_make_tool  # Use default tool factory
+
+    uri = cwl_link if cwl_link else "api://user-submitted-raw-text.cwl"
+
+    # Validate the entire CWL document (load_tool is what catches JSX errors)
     try:
-        # Check for cwltool errors (i.e. JSX error when NodeJS missing)
-        # Parse YAML - use a custom loader to prevent date string conversion
-        class NoDatesSafeLoader(yaml.SafeLoader):
-            pass
-        NoDatesSafeLoader.yaml_implicit_resolvers = {
-            k: [r for r in v if r[0] != 'tag:yaml.org,2002:timestamp']
-            for k, v in NoDatesSafeLoader.yaml_implicit_resolvers.items()
-        }
         cwl_dict = yaml.load(cwl_text, Loader=NoDatesSafeLoader)
+        load_tool(cwl_dict, loading_context)
+        cwl_obj = load_document_by_string(cwl_text, uri=uri, load_all=True)
+    except Exception as err:
+        log.error(f"CWL validation failed: {err}")
+        raise ValueError(f"CWL validation failed: {str(err)}")
+    
+    # Now parse the CWL document for relevant metadata and throw errors if required fields missing
+    # Ensure cwl_obj is iterable (should be a list when load_all=True)
+    try:
+        cwl_obj = list(cwl_obj) if hasattr(cwl_obj, '__iter__') and not isinstance(cwl_obj, str) else [cwl_obj]
+    except TypeError:
+        raise ValueError("CWL file structure is invalid: unable to parse CWL document.")
 
-        # Set up LoadingContext to avoid fetching external files
-        loading_context = LoadingContext()
-        loading_context.do_update = False  # Don't update schemas, this causes unnecessary calls 
-        loading_context.disable_js_validation = False  # Keep JS validation
-        loading_context.construct_tool_object = default_make_tool  # Use default tool factory
+    workflow = next((obj for obj in cwl_obj if isinstance(obj, cwl_v1_2.Workflow)), None)
+    if not workflow:
+        raise ValueError("A valid Workflow object must be defined in the CWL file.")
 
-        uri = cwl_link if cwl_link else "api://user-submitted-raw-text.cwl"
+    cwl_id = workflow.id
+    version_match = re.search(r"s:version:[ \t]*(\S+)", cwl_text, re.IGNORECASE)
+    
+    if not version_match or not cwl_id:
+        raise ValueError("Required metadata missing: s:version and a top-level id are required.")
 
-        # Validate the entire CWL document (load_tool is what catches JSX errors)
-        try:
-            load_tool(cwl_dict, loading_context)
-            cwl_obj = load_document_by_string(cwl_text, uri=uri, load_all=True)
-        except Exception as err:
-            log.error(f"CWL validation failed: {err}")
-            raise ValueError(f"CWL validation failed: {str(err)}")
-        
-        # Now parse the CWL document for relevant metadata and throw errors if required fields missing
-        # Ensure cwl_obj is iterable (should be a list when load_all=True)
-        try:
-            cwl_obj = list(cwl_obj) if hasattr(cwl_obj, '__iter__') and not isinstance(cwl_obj, str) else [cwl_obj]
-        except TypeError:
-            raise ValueError("CWL file structure is invalid: unable to parse CWL document.")
+    fragment = urllib.parse.urlparse(cwl_id).fragment
+    cwl_id = os.path.basename(fragment)
+    process_version = version_match.group(1).strip().strip("'\"")
 
-        workflow = next((obj for obj in cwl_obj if isinstance(obj, cwl_v1_2.Workflow)), None)
-        if not workflow:
-            raise ValueError("A valid Workflow object must be defined in the CWL file.")
+    if not process_version:
+        raise ValueError("Required metadata missing: s:version must have a non-empty value.")
 
-        cwl_id = workflow.id
-        version_match = re.search(r"s:version:[ \t]*(\S+)", cwl_text, re.IGNORECASE)
-        
-        if not version_match or not cwl_id:
-            raise ValueError("Required metadata missing: s:version and a top-level id are required.")
+    if ":" in process_version:
+        raise ValueError("Process version cannot contain a :")
 
-        fragment = urllib.parse.urlparse(cwl_id).fragment
-        cwl_id = os.path.basename(fragment)
-        print("graceal1 cwl_id is ")
-        print(cwl_id)
-        logging.error("graceal1 cwl id is ")
-        logging.error(cwl_id)
-        process_version = version_match.group(1).strip().strip("'\"")
+    # Get git information
+    github_url = re.search(r"s:codeRepository:\s*(\S+)", cwl_text, re.IGNORECASE)
+    github_url = github_url.group(1) if github_url else None
+    git_commit_hash = re.search(r"s:commitHash:\s*(\S+)", cwl_text, re.IGNORECASE)
+    git_commit_hash = git_commit_hash.group(1) if git_commit_hash else None
 
-        if not process_version:
-            raise ValueError("Required metadata missing: s:version must have a non-empty value.")
+    keywords_match = re.search(r"s:keywords:\s*(.*)", cwl_text, re.IGNORECASE)
+    keywords = keywords_match.group(1).replace(" ", "") if keywords_match else None
 
-        if ":" in process_version:
-            raise ValueError("Process version cannot contain a :")
-
-        # Get git information
-        github_url = re.search(r"s:codeRepository:\s*(\S+)", cwl_text, re.IGNORECASE)
-        github_url = github_url.group(1) if github_url else None
-        git_commit_hash = re.search(r"s:commitHash:\s*(\S+)", cwl_text, re.IGNORECASE)
-        git_commit_hash = git_commit_hash.group(1) if git_commit_hash else None
-
-        keywords_match = re.search(r"s:keywords:\s*(.*)", cwl_text, re.IGNORECASE)
-        keywords = keywords_match.group(1).replace(" ", "") if keywords_match else None
-
-        try:
-            author_match = re.search(
-                r"s:author:.*?s:name:\s*(\S+)",
-                cwl_text,
-                re.DOTALL | re.IGNORECASE
-            )
-            author = author_match.group(1) if author_match else None
-        except Exception as e:
-            author = None
-            log.error(f"Failed to get author name: {e}")
-
-        # Find the CommandLineTool run by the first step of the workflow
-        if workflow.steps:
-            # Get the ID of the tool to run (e.g., '#main')
-            tool_id_ref = workflow.steps[0].run
-            # The actual ID is the part after the '#'
-            tool_id = os.path.basename(tool_id_ref)
-
-            # Find the CommandLineTool object in the parsed CWL graph
-            command_line_tool = next((obj for obj in cwl_obj if isinstance(obj, cwl_v1_2.CommandLineTool) and obj.id.endswith(tool_id)), None)
-        
-            if command_line_tool:
-                # Extract the baseCommand directly
-                base_command = command_line_tool.baseCommand
-        
-                # Find the ResourceRequirement to extract ramMin and coresMin
-                if command_line_tool.requirements:
-                    for req in command_line_tool.requirements:
-                        if isinstance(req, cwl_v1_2.ResourceRequirement):
-                            ram_min = req.ramMin if req.ramMin else ram_min
-                            cores_min = req.coresMin if req.coresMin else cores_min
-                            break  # Stop after finding the first ResourceRequirement
-
+    try:
+        author_match = re.search(
+            r"s:author:.*?s:name:\s*(\S+)",
+            cwl_text,
+            re.DOTALL | re.IGNORECASE
+        )
+        author = author_match.group(1) if author_match else None
     except Exception as e:
-        log.error(f"Failed to parse or validate CWL: {e}")
-        raise ValueError(f"CWL file is not in the right format or is invalid: {str(e)}")
+        author = None
+        log.error(f"Failed to get author name: {e}")
+
+    # Find the CommandLineTool run by the first step of the workflow
+    if workflow.steps:
+        # Get the ID of the tool to run (e.g., '#main')
+        tool_id_ref = workflow.steps[0].run
+        # The actual ID is the part after the '#'
+        tool_id = os.path.basename(tool_id_ref)
+
+        # Find the CommandLineTool object in the parsed CWL graph
+        command_line_tool = next((obj for obj in cwl_obj if isinstance(obj, cwl_v1_2.CommandLineTool) and obj.id.endswith(tool_id)), None)
+    
+        if command_line_tool:
+            # Extract the baseCommand directly
+            base_command = command_line_tool.baseCommand
+    
+            # Find the ResourceRequirement to extract ramMin and coresMin
+            if command_line_tool.requirements:
+                for req in command_line_tool.requirements:
+                    if isinstance(req, cwl_v1_2.ResourceRequirement):
+                        ram_min = req.ramMin if req.ramMin else ram_min
+                        cores_min = req.coresMin if req.coresMin else cores_min
+                        break  # Stop after finding the first ResourceRequirement
 
     return CWL_METADATA(
         id=cwl_id,

--- a/test/api/endpoints/test_build.py
+++ b/test/api/endpoints/test_build.py
@@ -651,21 +651,6 @@ class TestBuildEndpoints(unittest.TestCase):
 
             self.assertIn("Invalid CWL file", str(cm.exception))
 
-    def test_create_process_deployment_missing_cwl_link(self):
-        """Test OGC process deployment with missing CWL link"""
-        
-        # Create test user
-        user_id = self._create_test_user()
-        
-        with app.app_context():
-            with self.assertRaises(ValueError) as cm:
-                create_process_deployment(
-                    cwl_link=None,
-                    user_id=user_id
-                )
-            
-            self.assertEqual(str(cm.exception), "CWL file is not in the right format or is invalid.")
-
     def test_create_process_deployment_invalid_user(self):
         """Test OGC process deployment with invalid user ID"""
         


### PR DESCRIPTION
Changed this to the more pythonic way based on Sujen's suggestion
`load_tool` is what throws the JSX error (validation error James was getting and the only known validation error that isn't thrown by load_document_by_string)

removed test_create_process_deployment_missing_cwl_link because cwl_link can be None for get_cwl_metadata
