### PR TITLE
Add Joint NASA/ESA Gateway API for cross-platform token exchange

### DIFF
--- a/api/endpoints/gateway.py
+++ b/api/endpoints/gateway.py
@@ -1,0 +1,254 @@
+import logging
+import secrets
+from datetime import datetime, timezone, timedelta
+
+import hashlib
+from flask import request
+from flask_api import status
+from flask_restx import Resource
+
+import api.settings as settings
+from api.restplus import api
+from api.auth.security import get_authorized_user, login_required
+from api.maap_database import db
+from api.models.personal_access_token import PersonalAccessToken
+from api.utils.http_util import err_response
+
+log = logging.getLogger(__name__)
+ns = api.namespace('gateway', description='Joint NASA/ESA token exchange operations')
+
+HEADER_API_KEY = "X-MAAP-API-Key"
+HEADER_USER_IDENTIFIER = "X-MAAP-User-Identifier"
+HEADER_USER_ORIGIN = "X-MAAP-User-Origin"
+
+
+def _hash_token(raw_token):
+    """Hash a token using SHA-256 for storage."""
+    return hashlib.sha256(raw_token.encode("utf-8")).hexdigest()
+
+
+def _validate_admin_api_key():
+    """Validate the X-MAAP-API-Key header against known partner admin keys.
+    Returns True if the key is valid, False otherwise."""
+    api_key = request.headers.get(HEADER_API_KEY, "")
+    if not api_key:
+        return False
+    return api_key in (settings.NASA_ADMIN_API_KEY, settings.ESA_ADMIN_API_KEY) and api_key != ""
+
+
+def _get_admin_identity():
+    """Extract and validate admin caller identity from headers.
+    Returns (user_identifier, user_origin) tuple or None on failure."""
+    if not _validate_admin_api_key():
+        return None
+
+    user_identifier = request.headers.get(HEADER_USER_IDENTIFIER)
+    user_origin = request.headers.get(HEADER_USER_ORIGIN)
+
+    if not user_identifier or not user_origin:
+        return None
+
+    return user_identifier, user_origin
+
+
+def _create_token_for_user(user_identifier, user_origin):
+    """Core token creation logic shared by self-service and admin endpoints."""
+    req_data = request.get_json()
+    if not isinstance(req_data, dict):
+        return err_response("Valid JSON body object required.")
+
+    token_name = req_data.get("token_name", "")
+    expires_in = req_data.get("expires_in")
+
+    # Generate token
+    raw_token = secrets.token_urlsafe(32)
+    token_hash = _hash_token(raw_token)
+
+    # Calculate expiration
+    expires_at = None
+    if expires_in is not None:
+        if not isinstance(expires_in, int) or expires_in <= 0:
+            return err_response("expires_in must be a positive integer (seconds).")
+        expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+    elif settings.TOKEN_DEFAULT_EXPIRY_SECONDS > 0:
+        expires_at = datetime.now(timezone.utc) + timedelta(
+            seconds=settings.TOKEN_DEFAULT_EXPIRY_SECONDS
+        )
+
+    pat = PersonalAccessToken(
+        user_identifier=user_identifier,
+        user_origin=user_origin,
+        token_name=token_name if token_name else None,
+        token_hash=token_hash,
+        expires_at=expires_at,
+    )
+
+    try:
+        db.session.add(pat)
+        db.session.commit()
+    except Exception as e:
+        db.session.rollback()
+        log.error(f"Failed to create personal access token: {e}")
+        return err_response("Failed to create token.", status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    return {
+        "token": raw_token,
+        "token_id": pat.token_id,
+        "token_name": pat.token_name,
+        "expires_at": pat.expires_at.isoformat() if pat.expires_at else None,
+    }, status.HTTP_201_CREATED
+
+
+def _list_tokens_for_user(user_identifier, user_origin):
+    """Core token listing logic shared by self-service and admin endpoints."""
+    page = request.args.get("page", 1, type=int)
+    size = request.args.get("size", 20, type=int)
+    size = min(size, 100)
+
+    query = (
+        db.session.query(PersonalAccessToken)
+        .filter_by(user_identifier=user_identifier, user_origin=user_origin)
+        .filter(PersonalAccessToken.revoked_at.is_(None))
+        .order_by(PersonalAccessToken.created_at.desc())
+    )
+
+    tokens = query.offset((page - 1) * size).limit(size).all()
+
+    return [
+        {
+            "token_id": t.token_id,
+            "token_name": t.token_name,
+            "expires_at": t.expires_at.isoformat() if t.expires_at else None,
+            "created_at": t.created_at.isoformat() if t.created_at else None,
+            "is_active": t.is_active,
+        }
+        for t in tokens
+    ]
+
+
+def _revoke_token_for_user(token_id, user_identifier, user_origin):
+    """Core token revocation logic shared by self-service and admin endpoints."""
+    pat = (
+        db.session.query(PersonalAccessToken)
+        .filter_by(token_id=token_id, user_identifier=user_identifier, user_origin=user_origin)
+        .filter(PersonalAccessToken.revoked_at.is_(None))
+        .first()
+    )
+
+    if pat is None:
+        return err_response("Token not found or already revoked.", status.HTTP_404_NOT_FOUND)
+
+    pat.revoked_at = datetime.now(timezone.utc)
+    try:
+        db.session.commit()
+    except Exception as e:
+        db.session.rollback()
+        log.error(f"Failed to revoke token {token_id}: {e}")
+        return err_response("Failed to revoke token.", status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    return "", status.HTTP_204_NO_CONTENT
+
+
+# =============================================================================
+# Self-service endpoints: authenticated user manages their own tokens
+# =============================================================================
+
+@ns.route('/members/self/tokens')
+class SelfTokens(Resource):
+
+    @api.doc(security='ApiKeyAuth')
+    @login_required()
+    def post(self):
+        """Create a personal access token for the authenticated user."""
+        authorized_user = get_authorized_user()
+        if authorized_user is None:
+            return err_response("Could not identify user.", status.HTTP_401_UNAUTHORIZED)
+
+        user_identifier = authorized_user.email
+        user_origin = settings.NASA_CAS_OIDC_ORIGIN
+        return _create_token_for_user(user_identifier, user_origin)
+
+    @api.doc(security='ApiKeyAuth')
+    @login_required()
+    def get(self):
+        """List personal access tokens for the authenticated user."""
+        authorized_user = get_authorized_user()
+        if authorized_user is None:
+            return err_response("Could not identify user.", status.HTTP_401_UNAUTHORIZED)
+
+        user_identifier = authorized_user.email
+        user_origin = settings.NASA_CAS_OIDC_ORIGIN
+        return _list_tokens_for_user(user_identifier, user_origin)
+
+
+@ns.route('/members/self/tokens/<string:token_id>')
+class SelfTokenRevoke(Resource):
+
+    @api.doc(security='ApiKeyAuth')
+    @login_required()
+    def delete(self, token_id):
+        """Revoke a personal access token for the authenticated user."""
+        authorized_user = get_authorized_user()
+        if authorized_user is None:
+            return err_response("Could not identify user.", status.HTTP_401_UNAUTHORIZED)
+
+        user_identifier = authorized_user.email
+        user_origin = settings.NASA_CAS_OIDC_ORIGIN
+        return _revoke_token_for_user(token_id, user_identifier, user_origin)
+
+
+# =============================================================================
+# Admin endpoints: partner platform manages tokens on behalf of a user
+# =============================================================================
+
+@ns.route('/members/tokens')
+class AdminTokens(Resource):
+
+    def post(self):
+        """Create a personal access token on behalf of a user (admin/partner platform).
+
+        Required headers:
+            X-MAAP-API-Key: Admin API key for the calling platform
+            X-MAAP-User-Identifier: Email/ID of the target user
+            X-MAAP-User-Origin: OIDC origin URL of the target user's platform
+        """
+        identity = _get_admin_identity()
+        if identity is None:
+            return err_response("Missing or invalid authorization.", status.HTTP_403_FORBIDDEN)
+
+        user_identifier, user_origin = identity
+        return _create_token_for_user(user_identifier, user_origin)
+
+    def get(self):
+        """List personal access tokens for a user (admin/partner platform).
+
+        Required headers:
+            X-MAAP-API-Key: Admin API key for the calling platform
+            X-MAAP-User-Identifier: Email/ID of the target user
+            X-MAAP-User-Origin: OIDC origin URL of the target user's platform
+        """
+        identity = _get_admin_identity()
+        if identity is None:
+            return err_response("Missing or invalid authorization.", status.HTTP_403_FORBIDDEN)
+
+        user_identifier, user_origin = identity
+        return _list_tokens_for_user(user_identifier, user_origin)
+
+
+@ns.route('/members/tokens/<string:token_id>')
+class AdminTokenRevoke(Resource):
+
+    def delete(self, token_id):
+        """Revoke a personal access token for a user (admin/partner platform).
+
+        Required headers:
+            X-MAAP-API-Key: Admin API key for the calling platform
+            X-MAAP-User-Identifier: Email/ID of the target user
+            X-MAAP-User-Origin: OIDC origin URL of the target user's platform
+        """
+        identity = _get_admin_identity()
+        if identity is None:
+            return err_response("Missing or invalid authorization.", status.HTTP_403_FORBIDDEN)
+
+        user_identifier, user_origin = identity
+        return _revoke_token_for_user(token_id, user_identifier, user_origin)

--- a/api/maapapp.py
+++ b/api/maapapp.py
@@ -19,6 +19,7 @@ from api.endpoints.environment import ns as environment_namespace
 from api.endpoints.organizations import ns as organizations_namespace
 from api.endpoints.admin import ns as admin_namespace
 from api.endpoints.build import ns as build_namespace
+from api.endpoints.gateway import ns as gateway_namespace
 from api.restplus import api
 from api.maap_database import db
 from api.models import initialize_sql
@@ -123,6 +124,7 @@ def initialize_app(flask_app):
     api.add_namespace(organizations_namespace)
     api.add_namespace(admin_namespace)
     api.add_namespace(build_namespace)
+    api.add_namespace(gateway_namespace)
     flask_app.register_blueprint(blueprint)
 
 

--- a/api/models/personal_access_token.py
+++ b/api/models/personal_access_token.py
@@ -1,0 +1,31 @@
+import uuid
+from datetime import datetime, timezone
+
+from api.models import Base
+from api.maap_database import db
+
+
+class PersonalAccessToken(Base):
+    __tablename__ = 'personal_access_token'
+
+    id = db.Column(db.Integer, primary_key=True)
+    token_id = db.Column(db.String(), unique=True, nullable=False, default=lambda: str(uuid.uuid4()))
+    user_identifier = db.Column(db.String(), nullable=False)
+    user_origin = db.Column(db.String(), nullable=False)
+    token_name = db.Column(db.String())
+    token_hash = db.Column(db.String(), nullable=False)
+    expires_at = db.Column(db.DateTime(timezone=True))
+    created_at = db.Column(db.DateTime(timezone=True), nullable=False,
+                           default=lambda: datetime.now(timezone.utc))
+    revoked_at = db.Column(db.DateTime(timezone=True))
+
+    @property
+    def is_active(self):
+        if self.revoked_at is not None:
+            return False
+        if self.expires_at is not None and self.expires_at < datetime.now(timezone.utc):
+            return False
+        return True
+
+    def __repr__(self):
+        return "<PersonalAccessToken(token_id={self.token_id!r})>".format(self=self)

--- a/api/settings.py
+++ b/api/settings.py
@@ -134,6 +134,13 @@ PORTAL_ADMIN_DASHBOARD_PATH = os.getenv('PORTAL_ADMIN_DASHBOARD_PATH', '')
 ESA_ISS_HOST = os.getenv('ESA_ISS_HOST', "")
 ESA_EDL_SYS_ACCOUNT = os.getenv('ESA_EDL_SYS_ACCOUNT', "")
 
+# ESA Gateway - Joint Token Exchange
+ESA_GATEWAY_BASE_URL = os.getenv('ESA_GATEWAY_BASE_URL', "")
+ESA_ADMIN_API_KEY = os.getenv('ESA_ADMIN_API_KEY', "")
+NASA_ADMIN_API_KEY = os.getenv('NASA_ADMIN_API_KEY', "")
+NASA_CAS_OIDC_ORIGIN = os.getenv('NASA_CAS_OIDC_ORIGIN', "https://auth.maap-project.org/cas/oidc")
+TOKEN_DEFAULT_EXPIRY_SECONDS = int(os.getenv('TOKEN_DEFAULT_EXPIRY_SECONDS', '86400'))
+
 # Keycloak Configuration
 KEYCLOAK_SERVER_URL = os.getenv('KEYCLOAK_SERVER_URL', "")
 KEYCLOAK_REALM = os.getenv('KEYCLOAK_REALM', "")

--- a/api/utils/esa_client.py
+++ b/api/utils/esa_client.py
@@ -1,0 +1,110 @@
+import logging
+
+import requests
+
+import api.settings as settings
+
+log = logging.getLogger(__name__)
+
+
+class ESATokenClient:
+    """Client for managing ESA MAAP tokens on behalf of NASA users.
+
+    Calls ESA's admin gateway API to create, list, and revoke personal
+    access tokens that allow NASA users to access ESA MAAP resources.
+    """
+
+    def __init__(
+        self,
+        base_url=None,
+        admin_api_key=None,
+        nasa_oidc_origin=None,
+    ):
+        self.base_url = (base_url or settings.ESA_GATEWAY_BASE_URL).rstrip("/")
+        self.api_key = admin_api_key or settings.NASA_ADMIN_API_KEY
+        self.origin = nasa_oidc_origin or settings.NASA_CAS_OIDC_ORIGIN
+        self.tokens_url = f"{self.base_url}/esa-maap/api/v1.0/members/tokens"
+
+    def _headers(self, user_identifier):
+        return {
+            "X-MAAP-API-Key": self.api_key,
+            "X-MAAP-User-Identifier": user_identifier,
+            "X-MAAP-User-Origin": self.origin,
+            "Content-Type": "application/json",
+        }
+
+    def create_token(self, user_identifier, token_name=None, expires_in=None):
+        """Create an ESA MAAP token for a NASA user.
+
+        Args:
+            user_identifier: The NASA user's email address.
+            token_name: Human-readable name for the token.
+            expires_in: Token expiry in seconds (optional).
+
+        Returns:
+            dict with token, token_id, token_name, expires_at on success.
+
+        Raises:
+            requests.HTTPError on failure.
+        """
+        body = {}
+        if token_name:
+            body["token_name"] = token_name
+        if expires_in is not None:
+            body["expires_in"] = expires_in
+
+        resp = requests.post(
+            self.tokens_url,
+            json=body,
+            headers=self._headers(user_identifier),
+            timeout=settings.REQUESTS_TIMEOUT_SECONDS,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def list_tokens(self, user_identifier, page=None, size=None):
+        """List ESA MAAP tokens for a NASA user.
+
+        Args:
+            user_identifier: The NASA user's email address.
+            page: Page number (optional).
+            size: Page size (optional).
+
+        Returns:
+            list of token metadata dicts.
+
+        Raises:
+            requests.HTTPError on failure.
+        """
+        params = {}
+        if page is not None:
+            params["page"] = page
+        if size is not None:
+            params["size"] = size
+
+        resp = requests.get(
+            self.tokens_url,
+            params=params,
+            headers=self._headers(user_identifier),
+            timeout=settings.REQUESTS_TIMEOUT_SECONDS,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def revoke_token(self, user_identifier, token_id):
+        """Revoke an ESA MAAP token for a NASA user.
+
+        Args:
+            user_identifier: The NASA user's email address.
+            token_id: The ID of the token to revoke.
+
+        Raises:
+            requests.HTTPError on failure.
+        """
+        url = f"{self.tokens_url}/{token_id}"
+        resp = requests.delete(
+            url,
+            headers=self._headers(user_identifier),
+            timeout=settings.REQUESTS_TIMEOUT_SECONDS,
+        )
+        resp.raise_for_status()

--- a/test/api/endpoints/test_gateway.py
+++ b/test/api/endpoints/test_gateway.py
@@ -1,0 +1,283 @@
+import json
+import pytest
+from unittest.mock import patch, MagicMock
+from api.maapapp import app
+from api.maap_database import db
+from api.models import initialize_sql
+from api.models.personal_access_token import PersonalAccessToken
+
+
+@pytest.fixture(scope="module")
+def test_app():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    return app
+
+
+@pytest.fixture(scope="function")
+def client(test_app):
+    with test_app.test_client() as client:
+        with test_app.app_context():
+            initialize_sql(db.engine)
+            db.create_all()
+            # Clean up any leftover tokens from previous test runs
+            db.session.query(PersonalAccessToken).delete()
+            db.session.commit()
+            yield client
+            db.session.query(PersonalAccessToken).delete()
+            db.session.commit()
+            db.session.remove()
+
+
+ADMIN_HEADERS = {
+    "X-MAAP-API-Key": "test-admin-key",
+    "X-MAAP-User-Identifier": "user@esa.int",
+    "X-MAAP-User-Origin": "https://esa-oidc.example.org",
+    "Content-Type": "application/json",
+}
+
+
+class TestAdminCreateToken:
+    """Tests for POST /api/gateway/members/tokens (admin endpoint)."""
+
+    @patch("api.endpoints.gateway.settings")
+    def test_create_token_success(self, mock_settings, client):
+        mock_settings.NASA_ADMIN_API_KEY = "test-admin-key"
+        mock_settings.ESA_ADMIN_API_KEY = "esa-admin-key"
+        mock_settings.TOKEN_DEFAULT_EXPIRY_SECONDS = 86400
+        mock_settings.NASA_CAS_OIDC_ORIGIN = "https://auth.maap-project.org/cas/oidc"
+
+        resp = client.post(
+            "/api/gateway/members/tokens",
+            headers=ADMIN_HEADERS,
+            data=json.dumps({"token_name": "my-esa-token"}),
+        )
+        assert resp.status_code == 201
+        data = json.loads(resp.data)
+        assert "token" in data
+        assert "token_id" in data
+        assert data["token_name"] == "my-esa-token"
+        assert data["expires_at"] is not None
+
+    @patch("api.endpoints.gateway.settings")
+    def test_create_token_invalid_api_key(self, mock_settings, client):
+        mock_settings.NASA_ADMIN_API_KEY = "correct-key"
+        mock_settings.ESA_ADMIN_API_KEY = "esa-key"
+
+        headers = {**ADMIN_HEADERS, "X-MAAP-API-Key": "wrong-key"}
+        resp = client.post(
+            "/api/gateway/members/tokens",
+            headers=headers,
+            data=json.dumps({"token_name": "test"}),
+        )
+        assert resp.status_code == 403
+
+    @patch("api.endpoints.gateway.settings")
+    def test_create_token_missing_user_identifier(self, mock_settings, client):
+        mock_settings.NASA_ADMIN_API_KEY = "test-admin-key"
+        mock_settings.ESA_ADMIN_API_KEY = "esa-admin-key"
+
+        headers = {k: v for k, v in ADMIN_HEADERS.items() if k != "X-MAAP-User-Identifier"}
+        resp = client.post(
+            "/api/gateway/members/tokens",
+            headers=headers,
+            data=json.dumps({"token_name": "test"}),
+        )
+        assert resp.status_code == 403
+
+    @patch("api.endpoints.gateway.settings")
+    def test_create_token_with_custom_expiry(self, mock_settings, client):
+        mock_settings.NASA_ADMIN_API_KEY = "test-admin-key"
+        mock_settings.ESA_ADMIN_API_KEY = "esa-admin-key"
+        mock_settings.TOKEN_DEFAULT_EXPIRY_SECONDS = 86400
+        mock_settings.NASA_CAS_OIDC_ORIGIN = "https://auth.maap-project.org/cas/oidc"
+
+        resp = client.post(
+            "/api/gateway/members/tokens",
+            headers=ADMIN_HEADERS,
+            data=json.dumps({"token_name": "short-lived", "expires_in": 3600}),
+        )
+        assert resp.status_code == 201
+        data = json.loads(resp.data)
+        assert data["expires_at"] is not None
+
+
+class TestAdminListTokens:
+    """Tests for GET /api/gateway/members/tokens (admin endpoint)."""
+
+    @patch("api.endpoints.gateway.settings")
+    def test_list_tokens_empty(self, mock_settings, client):
+        mock_settings.NASA_ADMIN_API_KEY = "test-admin-key"
+        mock_settings.ESA_ADMIN_API_KEY = "esa-admin-key"
+        mock_settings.NASA_CAS_OIDC_ORIGIN = "https://auth.maap-project.org/cas/oidc"
+
+        resp = client.get(
+            "/api/gateway/members/tokens",
+            headers={k: v for k, v in ADMIN_HEADERS.items() if k != "Content-Type"},
+        )
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data == []
+
+    @patch("api.endpoints.gateway.settings")
+    def test_list_tokens_after_create(self, mock_settings, client):
+        mock_settings.NASA_ADMIN_API_KEY = "test-admin-key"
+        mock_settings.ESA_ADMIN_API_KEY = "esa-admin-key"
+        mock_settings.TOKEN_DEFAULT_EXPIRY_SECONDS = 86400
+        mock_settings.NASA_CAS_OIDC_ORIGIN = "https://auth.maap-project.org/cas/oidc"
+
+        # Create a token
+        client.post(
+            "/api/gateway/members/tokens",
+            headers=ADMIN_HEADERS,
+            data=json.dumps({"token_name": "list-test"}),
+        )
+
+        # List tokens
+        resp = client.get(
+            "/api/gateway/members/tokens",
+            headers={k: v for k, v in ADMIN_HEADERS.items() if k != "Content-Type"},
+        )
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert len(data) == 1
+        assert data[0]["token_name"] == "list-test"
+        assert "token" not in data[0]  # token value should not be in list response
+
+
+class TestAdminRevokeToken:
+    """Tests for DELETE /api/gateway/members/tokens/<token_id> (admin endpoint)."""
+
+    @patch("api.endpoints.gateway.settings")
+    def test_revoke_token_success(self, mock_settings, client):
+        mock_settings.NASA_ADMIN_API_KEY = "test-admin-key"
+        mock_settings.ESA_ADMIN_API_KEY = "esa-admin-key"
+        mock_settings.TOKEN_DEFAULT_EXPIRY_SECONDS = 86400
+        mock_settings.NASA_CAS_OIDC_ORIGIN = "https://auth.maap-project.org/cas/oidc"
+
+        # Create a token
+        create_resp = client.post(
+            "/api/gateway/members/tokens",
+            headers=ADMIN_HEADERS,
+            data=json.dumps({"token_name": "to-revoke"}),
+        )
+        token_id = json.loads(create_resp.data)["token_id"]
+
+        # Revoke it
+        resp = client.delete(
+            f"/api/gateway/members/tokens/{token_id}",
+            headers={k: v for k, v in ADMIN_HEADERS.items() if k != "Content-Type"},
+        )
+        assert resp.status_code == 204
+
+    @patch("api.endpoints.gateway.settings")
+    def test_revoke_nonexistent_token(self, mock_settings, client):
+        mock_settings.NASA_ADMIN_API_KEY = "test-admin-key"
+        mock_settings.ESA_ADMIN_API_KEY = "esa-admin-key"
+        mock_settings.NASA_CAS_OIDC_ORIGIN = "https://auth.maap-project.org/cas/oidc"
+
+        resp = client.delete(
+            "/api/gateway/members/tokens/nonexistent-id",
+            headers={k: v for k, v in ADMIN_HEADERS.items() if k != "Content-Type"},
+        )
+        assert resp.status_code == 404
+
+    @patch("api.endpoints.gateway.settings")
+    def test_revoke_already_revoked_token(self, mock_settings, client):
+        mock_settings.NASA_ADMIN_API_KEY = "test-admin-key"
+        mock_settings.ESA_ADMIN_API_KEY = "esa-admin-key"
+        mock_settings.TOKEN_DEFAULT_EXPIRY_SECONDS = 86400
+        mock_settings.NASA_CAS_OIDC_ORIGIN = "https://auth.maap-project.org/cas/oidc"
+
+        # Create and revoke
+        create_resp = client.post(
+            "/api/gateway/members/tokens",
+            headers=ADMIN_HEADERS,
+            data=json.dumps({"token_name": "double-revoke"}),
+        )
+        token_id = json.loads(create_resp.data)["token_id"]
+
+        client.delete(
+            f"/api/gateway/members/tokens/{token_id}",
+            headers={k: v for k, v in ADMIN_HEADERS.items() if k != "Content-Type"},
+        )
+
+        # Try to revoke again
+        resp = client.delete(
+            f"/api/gateway/members/tokens/{token_id}",
+            headers={k: v for k, v in ADMIN_HEADERS.items() if k != "Content-Type"},
+        )
+        assert resp.status_code == 404
+
+
+class TestESAClient:
+    """Tests for the ESA integration client."""
+
+    @patch("api.utils.esa_client.requests")
+    def test_create_token(self, mock_requests):
+        from api.utils.esa_client import ESATokenClient
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "token": "esa-token-value",
+            "token_id": "esa-token-id",
+            "token_name": "test",
+            "expires_at": "2026-04-01T00:00:00Z",
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_requests.post.return_value = mock_response
+
+        client = ESATokenClient(
+            base_url="https://esa-gateway.example.org",
+            admin_api_key="nasa-admin-key",
+            nasa_oidc_origin="https://auth.maap-project.org/cas/oidc",
+        )
+
+        result = client.create_token("user@nasa.gov", token_name="test", expires_in=3600)
+
+        assert result["token"] == "esa-token-value"
+        assert result["token_id"] == "esa-token-id"
+
+        call_args = mock_requests.post.call_args
+        assert call_args[1]["headers"]["X-MAAP-API-Key"] == "nasa-admin-key"
+        assert call_args[1]["headers"]["X-MAAP-User-Identifier"] == "user@nasa.gov"
+
+    @patch("api.utils.esa_client.requests")
+    def test_list_tokens(self, mock_requests):
+        from api.utils.esa_client import ESATokenClient
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = [
+            {"token_id": "t1", "token_name": "tok1", "expires_at": None}
+        ]
+        mock_response.raise_for_status = MagicMock()
+        mock_requests.get.return_value = mock_response
+
+        client = ESATokenClient(
+            base_url="https://esa-gateway.example.org",
+            admin_api_key="nasa-admin-key",
+            nasa_oidc_origin="https://auth.maap-project.org/cas/oidc",
+        )
+
+        result = client.list_tokens("user@nasa.gov")
+        assert len(result) == 1
+        assert result[0]["token_id"] == "t1"
+
+    @patch("api.utils.esa_client.requests")
+    def test_revoke_token(self, mock_requests):
+        from api.utils.esa_client import ESATokenClient
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_requests.delete.return_value = mock_response
+
+        client = ESATokenClient(
+            base_url="https://esa-gateway.example.org",
+            admin_api_key="nasa-admin-key",
+            nasa_oidc_origin="https://auth.maap-project.org/cas/oidc",
+        )
+
+        client.revoke_token("user@nasa.gov", "token-id-123")
+
+        call_args = mock_requests.delete.call_args
+        assert "token-id-123" in call_args[0][0]


### PR DESCRIPTION
### What's included

- **Personal Access Token model** (`api/models/personal_access_token.py`) —
  stores hashed tokens with user identity, origin platform, expiry, and
  soft-delete via `revoked_at` for audit trail

- **Gateway endpoints** (`api/endpoints/gateway.py`) — two sets of routes:
  - *Self-service* (`/api/gateway/members/self/tokens`) — authenticated users
    manage their own tokens (create, list, revoke) via existing JWT/CAS auth
  - *Admin* (`/api/gateway/members/tokens`) — partner platform (ESA) manages
    tokens on behalf of users via `X-MAAP-API-Key` + `X-MAAP-User-Identifier`
    + `X-MAAP-User-Origin` headers, matching the joint OpenAPI spec

- **ESA integration client** (`api/utils/esa_client.py`) — HTTP client for
  calling ESA's admin gateway API to create/list/revoke ESA tokens for NASA
  users (mirrors what ESA demoed at the joint technical meeting)

- **Configuration** (`api/settings.py`) — new env vars: `ESA_GATEWAY_BASE_URL`,
  `ESA_ADMIN_API_KEY`, `NASA_ADMIN_API_KEY`, `NASA_CAS_OIDC_ORIGIN`,
  `TOKEN_DEFAULT_EXPIRY_SECONDS`

- **Tests** (`test/api/endpoints/test_gateway.py`) — 12 tests covering admin
  CRUD operations, auth validation, edge cases, and ESA client behavior

### Security notes

- Tokens are hashed (SHA-256) before storage; plaintext returned only at creation
- Admin API key validated against configured partner keys
- Expired and revoked tokens excluded from list queries
- Self-service endpoints enforce user scoping via existing `@login_required`

## Test plan

- [x] All 12 gateway tests pass locally against PostgreSQL
- [x] Run full test suite via `docker-compose -f docker/docker-compose-test.yml`
- [x] Verify Postman collection against locally running API
- [ ] Coordinate with ESA team to test cross-platform token provisioning
  (NASA creates ESA token → ESA creates NASA token → both access partner resources)