### PR TITLE
API Gateway enhancements

### DIFF
--- a/api/endpoints/gateway.py
+++ b/api/endpoints/gateway.py
@@ -8,9 +8,11 @@ from flask_api import status
 from flask_restx import Resource
 
 import api.settings as settings
+from api import constants
 from api.restplus import api
 from api.auth.security import get_authorized_user, login_required
 from api.maap_database import db
+from api.models.member import Member
 from api.models.personal_access_token import PersonalAccessToken
 from api.utils.http_util import err_response
 
@@ -49,6 +51,16 @@ def _get_admin_identity():
         return None
 
     return user_identifier, user_origin
+
+
+def _verify_member_exists(user_identifier):
+    """Check that a member with the given email exists and is active.
+    Returns the Member or None."""
+    return (
+        db.session.query(Member)
+        .filter_by(email=user_identifier, status=constants.STATUS_ACTIVE)
+        .first()
+    )
 
 
 def _create_token_for_user(user_identifier, user_origin):
@@ -99,8 +111,11 @@ def _create_token_for_user(user_identifier, user_origin):
     }, status.HTTP_201_CREATED
 
 
-def _list_tokens_for_user(user_identifier, user_origin):
+def _list_tokens_for_user(user_identifier, user_origin, check_member=False):
     """Core token listing logic shared by self-service and admin endpoints."""
+    if check_member and _verify_member_exists(user_identifier) is None:
+        return err_response("User not found.", status.HTTP_404_NOT_FOUND)
+
     page = request.args.get("page", 1, type=int)
     size = request.args.get("size", 20, type=int)
     size = min(size, 100)
@@ -232,7 +247,7 @@ class AdminTokens(Resource):
             return err_response("Missing or invalid authorization.", status.HTTP_403_FORBIDDEN)
 
         user_identifier, user_origin = identity
-        return _list_tokens_for_user(user_identifier, user_origin)
+        return _list_tokens_for_user(user_identifier, user_origin, check_member=True)
 
 
 @ns.route('/members/tokens/<string:token_id>')

--- a/api/endpoints/gateway.py
+++ b/api/endpoints/gateway.py
@@ -10,7 +10,7 @@ from flask_restx import Resource
 import api.settings as settings
 from api import constants
 from api.restplus import api
-from api.auth.security import get_authorized_user, login_required
+from api.auth.security import get_authorized_user, login_required, verify_jwt_token
 from api.maap_database import db
 from api.models.member import Member
 from api.models.personal_access_token import PersonalAccessToken
@@ -51,6 +51,22 @@ def _get_admin_identity():
         return None
 
     return user_identifier, user_origin
+
+
+def _is_jwt_auth():
+    """Check if the current request is authenticated via JWT (not a personal access token)."""
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header.lower().startswith("bearer "):
+        token = auth_header.split(" ", 1)[1]
+        return verify_jwt_token(token) is not None
+
+    # proxy-ticket or cpticket with jwt: prefix
+    for header_name in ("proxy-ticket", "cpticket"):
+        value = request.headers.get(header_name, "")
+        if value.lower().startswith("jwt:"):
+            return verify_jwt_token(value) is not None
+
+    return False
 
 
 def _verify_member_exists(user_identifier):
@@ -174,7 +190,10 @@ class SelfTokens(Resource):
     @api.doc(security='ApiKeyAuth')
     @login_required()
     def post(self):
-        """Create a personal access token for the authenticated user."""
+        """Create a personal access token for the authenticated user. Requires JWT authentication."""
+        if not _is_jwt_auth():
+            return err_response("JWT authentication required to create tokens.", status.HTTP_403_FORBIDDEN)
+
         authorized_user = get_authorized_user()
         if authorized_user is None:
             return err_response("Could not identify user.", status.HTTP_401_UNAUTHORIZED)
@@ -202,7 +221,10 @@ class SelfTokenRevoke(Resource):
     @api.doc(security='ApiKeyAuth')
     @login_required()
     def delete(self, token_id):
-        """Revoke a personal access token for the authenticated user."""
+        """Revoke a personal access token for the authenticated user. Requires JWT authentication."""
+        if not _is_jwt_auth():
+            return err_response("JWT authentication required to delete tokens.", status.HTTP_403_FORBIDDEN)
+
         authorized_user = get_authorized_user()
         if authorized_user is None:
             return err_response("Could not identify user.", status.HTTP_401_UNAUTHORIZED)

--- a/test/api/endpoints/test_gateway.py
+++ b/test/api/endpoints/test_gateway.py
@@ -1,10 +1,13 @@
 import json
 import pytest
+from datetime import datetime, timezone
 from unittest.mock import patch, MagicMock
 from api.maapapp import app
 from api.maap_database import db
 from api.models import initialize_sql
+from api.models.member import Member
 from api.models.personal_access_token import PersonalAccessToken
+from api.models.role import Role
 
 
 @pytest.fixture(scope="module")
@@ -35,6 +38,31 @@ ADMIN_HEADERS = {
     "X-MAAP-User-Origin": "https://esa-oidc.example.org",
     "Content-Type": "application/json",
 }
+
+
+def _ensure_test_member(email="user@esa.int"):
+    """Create a test member in the DB if one doesn't already exist."""
+    member = db.session.query(Member).filter_by(email=email).first()
+    if member is None:
+        # Ensure the guest role exists
+        role = db.session.query(Role).filter_by(id=Role.ROLE_GUEST).first()
+        if role is None:
+            role = Role(id=Role.ROLE_GUEST, role_name="guest")
+            db.session.add(role)
+            db.session.commit()
+
+        member = Member(
+            username=email.split("@")[0],
+            email=email,
+            first_name="Test",
+            last_name="User",
+            status="active",
+            role_id=Role.ROLE_GUEST,
+            creation_date=datetime.now(timezone.utc),
+        )
+        db.session.add(member)
+        db.session.commit()
+    return member
 
 
 class TestAdminCreateToken:
@@ -106,10 +134,26 @@ class TestAdminListTokens:
     """Tests for GET /api/gateway/members/tokens (admin endpoint)."""
 
     @patch("api.endpoints.gateway.settings")
+    def test_list_tokens_nonexistent_user_returns_404(self, mock_settings, client):
+        mock_settings.NASA_ADMIN_API_KEY = "test-admin-key"
+        mock_settings.ESA_ADMIN_API_KEY = "esa-admin-key"
+        mock_settings.NASA_CAS_OIDC_ORIGIN = "https://auth.maap-project.org/cas/oidc"
+
+        headers = {
+            "X-MAAP-API-Key": "test-admin-key",
+            "X-MAAP-User-Identifier": "nobody@example.com",
+            "X-MAAP-User-Origin": "https://esa-oidc.example.org",
+        }
+        resp = client.get("/api/gateway/members/tokens", headers=headers)
+        assert resp.status_code == 404
+
+    @patch("api.endpoints.gateway.settings")
     def test_list_tokens_empty(self, mock_settings, client):
         mock_settings.NASA_ADMIN_API_KEY = "test-admin-key"
         mock_settings.ESA_ADMIN_API_KEY = "esa-admin-key"
         mock_settings.NASA_CAS_OIDC_ORIGIN = "https://auth.maap-project.org/cas/oidc"
+
+        _ensure_test_member("user@esa.int")
 
         resp = client.get(
             "/api/gateway/members/tokens",
@@ -125,6 +169,8 @@ class TestAdminListTokens:
         mock_settings.ESA_ADMIN_API_KEY = "esa-admin-key"
         mock_settings.TOKEN_DEFAULT_EXPIRY_SECONDS = 86400
         mock_settings.NASA_CAS_OIDC_ORIGIN = "https://auth.maap-project.org/cas/oidc"
+
+        _ensure_test_member("user@esa.int")
 
         # Create a token
         client.post(


### PR DESCRIPTION
- Restrict self-service token create (POST) and revoke (DELETE) on /gateway/members/self/tokens to JWT-authenticated users only — PAT-authenticated users can still list tokens and access the rest of the API
- Return 404 instead of an empty list when the admin GET /gateway/members/tokens endpoint is called for a non-existent or inactive user