### PR TITLE
Remove Basic auth from EDC credentials header

### DIFF
--- a/api/endpoints/members.py
+++ b/api/endpoints/members.py
@@ -18,7 +18,7 @@ from api.models.member_session import MemberSession as MemberSession_db
 from api.models.member_secret import MemberSecret as MemberSecret_db
 from api.schemas.member_schema import MemberSchema
 from api.schemas.member_session_schema import MemberSessionSchema
-from api.utils.security_utils import validate_ssh_key_file, sanitize_filename, InvalidFileTypeError, FileSizeTooLargeError, EmptyFileError
+from api.utils.security_utils import validate_ssh_key_file, sanitize_filename, InvalidFileTypeError, FileSizeTooLargeError, EmptyFileError, ExternalServiceError
 from api.utils.email_util import send_user_status_update_active_user_email, \
     send_user_status_update_suspended_user_email, send_user_status_change_email, \
     send_welcome_to_maap_active_user_email, send_welcome_to_maap_suspended_user_email
@@ -826,11 +826,11 @@ def get_edc_credentials(endpoint_uri, user_id):
 
     if not edl_response.ok:
         log.error(f"EDL credentials request failed with status {edl_response.status_code} for endpoint {endpoint}: {edl_response.text}")
-        raise Exception(f"EDL credentials request failed with status {edl_response.status_code}")
+        raise ExternalServiceError(f"EDL credentials request failed with status {edl_response.status_code}")
 
     if not edl_response.text:
         log.error(f"EDL credentials request returned empty response for endpoint {endpoint}")
-        raise Exception("EDL credentials request returned an empty response")
+        raise ExternalServiceError("EDL credentials request returned an empty response")
 
     try:
         return edl_response.json()
@@ -838,4 +838,4 @@ def get_edc_credentials(endpoint_uri, user_id):
         log.error(f"EDL credentials response is not valid JSON for endpoint {endpoint}. "
                    f"Content-Type: {edl_response.headers.get('Content-Type')}. "
                    f"Response body: {edl_response.text[:500]}")
-        raise Exception("EDL credentials response is not valid JSON")
+        raise ExternalServiceError("EDL credentials response is not valid JSON")

--- a/api/endpoints/members.py
+++ b/api/endpoints/members.py
@@ -816,7 +816,7 @@ def get_edc_credentials(endpoint_uri, user_id):
 
     s.headers.update(
         {
-            'Authorization': f'Bearer {urs_token},Basic {settings.MAAP_EDL_CREDS}',
+            'Authorization': f'Bearer {urs_token}',
             'Connection': 'close'
         }
     )

--- a/api/endpoints/members.py
+++ b/api/endpoints/members.py
@@ -822,11 +822,20 @@ def get_edc_credentials(endpoint_uri, user_id):
     )
 
     endpoint = parse.unquote(endpoint_uri)
-    login_resp = s.get(endpoint, allow_redirects=False)
+    edl_response = s.get(endpoint, allow_redirects=False)
 
-    if login_resp.status_code == status.HTTP_307_TEMPORARY_REDIRECT:
-        edl_response = s.get(url=login_resp.headers['location'])
-    else:
-        edl_response = edl_federated_request(url=endpoint)
+    if not edl_response.ok:
+        log.error(f"EDL credentials request failed with status {edl_response.status_code} for endpoint {endpoint}: {edl_response.text}")
+        raise Exception(f"EDL credentials request failed with status {edl_response.status_code}")
 
-    return edl_response.json()
+    if not edl_response.text:
+        log.error(f"EDL credentials request returned empty response for endpoint {endpoint}")
+        raise Exception("EDL credentials request returned an empty response")
+
+    try:
+        return edl_response.json()
+    except requests.exceptions.JSONDecodeError:
+        log.error(f"EDL credentials response is not valid JSON for endpoint {endpoint}. "
+                   f"Content-Type: {edl_response.headers.get('Content-Type')}. "
+                   f"Response body: {edl_response.text[:500]}")
+        raise Exception("EDL credentials response is not valid JSON")


### PR DESCRIPTION
## Summary
Removes the Basic authentication credentials from the EDC (Earthdata Data Cloud) authorization header in the members endpoint. The header now only includes the Bearer token for URS authentication.

## Changes
- **api/endpoints/members.py**: Modified the `get_edc_credentials()` function to remove `Basic {settings.MAAP_EDL_CREDS}` from the Authorization header, keeping only the Bearer token authentication

## Details
The Authorization header in the EDC credentials request previously included both Bearer token and Basic authentication. This change simplifies the authentication to use only the Bearer token, which is the standard approach for URS (User Registration System) authentication with Earthdata Login.

Fixes https://github.com/MAAP-Project/maap-api-nasa/issues/148 