### PR TITLE
Fix outdated User Guides + GitHub Issues links in registration email (#1236)

### DIFF
--- a/api/utils/email_util.py
+++ b/api/utils/email_util.py
@@ -273,10 +273,10 @@ def get_environment_info(base_url):
                 'open_policies': portal_base_url + "/open-policies/",
                 'privacy_policy': 'https://www.nasa.gov/about/highlights/HP_Privacy.html',
                 'tos': portal_base_url + "/terms-of-service/",
-                'user_guides': portal_base_url + "/user-guides/",
+                'user_guides': "https://docs.maap-project.org/en/latest/getting_started.html",
             },
             'github': {
-                'issues': 'https://github.com/MAAP-Project/ZenHub/issues'
+                'issues': 'https://github.com/MAAP-Project/Community/issues'
             },
         },
     }


### PR DESCRIPTION
The account emails render their URLs from `get_environment_info()` in `email_util.py`, and two were stale: User Guides pointed at the old `<env>.maap-project.org/user-guides/` WordPress path, and GitHub issues pointed at the retired `ZenHub` repo.

Pointed them at `docs.maap-project.org/en/latest/getting_started.html` and `MAAP-Project/Community/issues`. Since the URLs are centralized, this fixes all six templates that use these placeholders — no template edits needed. Verified both URLs return 200 and grep finds no remaining `user-guides`/`ZenHub` strings.

Closes [MAAP-Project/Community#1236](https://github.com/MAAP-Project/Community/issues/1236).