### PR TITLE
Update job_spec to use HYSDS_ROOT_WORK_DIR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [v5.0.1] - 2026-06-02
+- [pull/238](https://github.com/MAAP-Project/maap-api-nasa/pull/238) - Upgrade to Python 3.10
+
+## [v4.2.1] 
 - [pull/151](https://github.com/MAAP-Project/maap-api-nasa/pull/151) - Include MAAP-PGT token in MAAP API profile endpoints
 
 ## [v4.2.0] - 2025-02-19

--- a/api/auth/cas_auth.py
+++ b/api/auth/cas_auth.py
@@ -38,6 +38,13 @@ PROXY_TICKET_PREFIX = "PGT-"
 JWT_TOKEN_PREFIX = "jwt:"
 MEMBER_STATUS_ACTIVE = "active"
 MEMBER_STATUS_SUSPENDED = "suspended"
+EDL_BROKER_ALIAS = "edl"
+
+# Refresh the stored EDL (URS) access token this long before it expires.
+EDL_TOKEN_REFRESH_BUFFER = timedelta(minutes=5)
+# Per-process cache of EDL access-token expirations, keyed by member id, used to
+# avoid calling the Keycloak broker endpoint on every authenticated request.
+_edl_token_expiration_cache = {}
 
 def validate(service, ticket):
     """
@@ -320,6 +327,9 @@ def start_member_session_jwt(decoded_jwt, token_string, auto_create_member=False
             current_app.logger.error(f"Failed to add new member {usr}: {e}")
             raise
 
+    if member is not None:
+        refresh_urs_token(member, token_string)
+
     try:
         query = """INSERT INTO member_session (member_id, session_key, creation_date)
             VALUES ({}, '{}', '{}')
@@ -331,6 +341,60 @@ def start_member_session_jwt(decoded_jwt, token_string, auto_create_member=False
         raise
 
     return member
+
+
+def refresh_urs_token(member, kc_access_token):
+    """Refresh member.urs_token from the Keycloak EDL broker endpoint when it is
+    missing or close to expiring. Expirations are cached per-process by member id,
+    so the broker is not called on every authenticated request. Failures are logged
+    and leave the existing token in place — they must not break authentication."""
+    now = datetime.utcnow()
+    cached_expiration = _edl_token_expiration_cache.get(member.id)
+    if member.urs_token and cached_expiration is not None \
+            and now < cached_expiration - EDL_TOKEN_REFRESH_BUFFER:
+        return
+
+    broker_token = fetch_edl_broker_token(kc_access_token)
+    if not broker_token:
+        return
+
+    new_token = broker_token.get("access_token")
+    if not new_token:
+        return
+
+    # Prefer the absolute expiration epoch; fall back to expires_in if absent.
+    if broker_token.get("accessTokenExpiration") is not None:
+        _edl_token_expiration_cache[member.id] = datetime.utcfromtimestamp(broker_token["accessTokenExpiration"])
+    elif broker_token.get("expires_in") is not None:
+        _edl_token_expiration_cache[member.id] = now + timedelta(seconds=int(broker_token["expires_in"]))
+
+    if new_token != member.urs_token:
+        member.urs_token = new_token
+        try:
+            db.session.commit()
+        except Exception as e:
+            db.session.rollback()
+            current_app.logger.error(f"Failed to persist refreshed URS token for {member.username}: {e}")
+
+
+def fetch_edl_broker_token(kc_access_token):
+    """Retrieve the user's stored EarthData Login token set from the Keycloak
+    identity-provider broker endpoint. Returns the parsed JSON, or None on failure."""
+    if kc_access_token.startswith(JWT_TOKEN_PREFIX):
+        kc_access_token = kc_access_token[len(JWT_TOKEN_PREFIX):]
+
+    url = f"{settings.KEYCLOAK_SERVER_URL}realms/{settings.KEYCLOAK_REALM}/broker/{EDL_BROKER_ALIAS}/token"
+    try:
+        resp = requests.get(
+            url,
+            headers={'Authorization': f'Bearer {kc_access_token}'},
+            timeout=settings.REQUESTS_TIMEOUT_SECONDS,
+        )
+        resp.raise_for_status()
+        return resp.json()
+    except Exception as e:
+        current_app.logger.warning(f"Failed to retrieve EDL token from Keycloak broker: {e}")
+        return None
 
 
 def get_cas_attribute_value(attributes, attribute_key):

--- a/api/auth/cas_auth.py
+++ b/api/auth/cas_auth.py
@@ -1,4 +1,4 @@
-from datetime import timedelta, datetime
+from datetime import timedelta, datetime, timezone
 
 import flask
 import requests
@@ -348,7 +348,7 @@ def refresh_urs_token(member, kc_access_token):
     missing or close to expiring. Expirations are cached per-process by member id,
     so the broker is not called on every authenticated request. Failures are logged
     and leave the existing token in place — they must not break authentication."""
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     cached_expiration = _edl_token_expiration_cache.get(member.id)
     if member.urs_token and cached_expiration is not None \
             and now < cached_expiration - EDL_TOKEN_REFRESH_BUFFER:
@@ -364,7 +364,7 @@ def refresh_urs_token(member, kc_access_token):
 
     # Prefer the absolute expiration epoch; fall back to expires_in if absent.
     if broker_token.get("accessTokenExpiration") is not None:
-        _edl_token_expiration_cache[member.id] = datetime.utcfromtimestamp(broker_token["accessTokenExpiration"])
+        _edl_token_expiration_cache[member.id] = datetime.fromtimestamp(broker_token["accessTokenExpiration"], timezone.utc)
     elif broker_token.get("expires_in") is not None:
         _edl_token_expiration_cache[member.id] = now + timedelta(seconds=int(broker_token["expires_in"]))
 
@@ -372,9 +372,9 @@ def refresh_urs_token(member, kc_access_token):
         member.urs_token = new_token
         try:
             db.session.commit()
-        except Exception as e:
+        except Exception:
             db.session.rollback()
-            current_app.logger.error(f"Failed to persist refreshed URS token for {member.username}: {e}")
+            current_app.logger.exception(f"Failed to persist refreshed URS token for {member.username}")
 
 
 def fetch_edl_broker_token(kc_access_token):

--- a/api/utils/hysds_util.py
+++ b/api/utils/hysds_util.py
@@ -222,7 +222,7 @@ def create_job_spec(run_command, inputs, disk_usage, queue_name, verified=False)
     job_spec["command"] = "/app/dps_wrapper.sh '{}'".format(run_command)
     job_spec["disk_usage"] = disk_usage
     job_spec["imported_worker_files"] = {
-        "${DATA_DIR}/work/etc/maap-dps.env": "/home/ops/.maap-dps.env",
+        "${HYSDS_ROOT_WORK_DIR}/etc/maap-dps.env": "/home/ops/.maap-dps.env",
         "/tmp": ["/tmp", "rw"]
     }
     job_spec["post"] = ["hysds.triage.triage"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "maap-api-nasa"
-version = "5.0.0rc38"
+version = "5.1.0"
 description = "NASA Python implementation of the MAAP API specification"
 authors = ["MAAP-Project Platform <platform@MAAP-Project.github.com>"]
 license = "Apache 2.0"


### PR DESCRIPTION
HYSDS_ROOT_WORK_DIR is the variable that is set in the celery workers, and availability of DATA_DIR is not guaranteed.

### Testing 
Tested using job-eis-feds-dask-coordinator-v3:1.5.1 existing algorithm, by making change in the job spec in the database and running it on the older DPS workers and newer (OGC) workers. 