### PR TITLE
Use HYSDS_ROOT_WORK_DIR in job_spec

### DIFF
--- a/api/utils/hysds_util.py
+++ b/api/utils/hysds_util.py
@@ -222,7 +222,7 @@ def create_job_spec(run_command, inputs, disk_usage, queue_name, verified=False)
     job_spec["command"] = "/app/dps_wrapper.sh '{}'".format(run_command)
     job_spec["disk_usage"] = disk_usage
     job_spec["imported_worker_files"] = {
-        "${DATA_DIR}/work/etc/maap-dps.env": "/home/ops/.maap-dps.env",
+        "${HYSDS_ROOT_WORK_DIR}/etc/maap-dps.env": "/home/ops/.maap-dps.env",
         "/tmp": ["/tmp", "rw"]
     }
     job_spec["post"] = ["hysds.triage.triage"]


### PR DESCRIPTION
HYSDS_ROOT_WORK_DIR is the variable that is set in the celery workers, and availability of DATA_DIR is not guaranteed.

Testing
Tested using job-eis-feds-dask-coordinator-v3:1.5.1 existing algorithm, by making change in the job spec in the database and running it on the older DPS workers and newer (OGC) workers.