### PR TITLE
Implement EDL token refresh mechanism and update member model

### DIFF
--- a/api/auth/cas_auth.py
+++ b/api/auth/cas_auth.py
@@ -1,4 +1,4 @@
-from datetime import timedelta, datetime
+from datetime import timedelta, datetime, timezone
 
 import flask
 import requests
@@ -38,6 +38,11 @@ PROXY_TICKET_PREFIX = "PGT-"
 JWT_TOKEN_PREFIX = "jwt:"
 MEMBER_STATUS_ACTIVE = "active"
 MEMBER_STATUS_SUSPENDED = "suspended"
+
+
+def utcnow():
+    """Naive UTC now — timestamp columns (member, member_session) store naive UTC."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)
 EDL_BROKER_ALIAS = "edl"
 
 # Refresh the stored EDL (URS) access token this long before it expires.
@@ -115,7 +120,7 @@ def validate_proxy(ticket, auto_create_member=False):
     cas_session = db.session.query(MemberSession).filter_by(session_key=decrypted_ticket).first()
 
     # Check for active session created within allowed timespan
-    if cas_session is not None and cas_session.creation_date + timedelta(days=pgt_token_duration_in_days) > datetime.utcnow():
+    if cas_session is not None and cas_session.creation_date + timedelta(days=pgt_token_duration_in_days) > utcnow():
         return cas_session
     else:
         cas_validate_proxy_url = create_cas_proxy_url(
@@ -261,7 +266,7 @@ def start_member_session(cas_response, ticket, auto_create_member=False):
                         urs_token=urs_access_token,
                         role_id=Role.ROLE_MEMBER if is_esa_user else Role.ROLE_GUEST,
                         status=MEMBER_STATUS_ACTIVE if is_esa_user else MEMBER_STATUS_SUSPENDED,
-                        creation_date=datetime.utcnow())
+                        creation_date=utcnow())
         try:
             db.session.add(member)
         except Exception as e:
@@ -278,7 +283,7 @@ def start_member_session(cas_response, ticket, auto_create_member=False):
         current_app.logger.error(f"Failed to update member {usr}: {e}")
         raise
 
-    member_session = MemberSession(member_id=member.id, session_key=ticket, creation_date=datetime.utcnow())
+    member_session = MemberSession(member_id=member.id, session_key=ticket, creation_date=utcnow())
     try:
         db.session.add(member_session)
         db.session.commit()
@@ -315,7 +320,7 @@ def start_member_session_jwt(decoded_jwt, token_string, auto_create_member=False
                         email=decoded_jwt.get("email"),
                         role_id=Role.ROLE_MEMBER,
                         status=MEMBER_STATUS_ACTIVE,
-                        creation_date=datetime.utcnow())
+                        creation_date=utcnow())
         try:
             db.session.add(member)
             db.session.commit()
@@ -330,7 +335,7 @@ def start_member_session_jwt(decoded_jwt, token_string, auto_create_member=False
     try:
         query = """INSERT INTO member_session (member_id, session_key, creation_date)
             VALUES ({}, '{}', '{}')
-            ON CONFLICT (session_key) DO NOTHING;""".format(member.id, token_string, datetime.utcnow())
+            ON CONFLICT (session_key) DO NOTHING;""".format(member.id, token_string, utcnow())
         db.session.execute(sqlalchemy.text(query))
     except Exception as e:
         db.session.rollback()
@@ -348,7 +353,7 @@ def refresh_urs_token(member, kc_access_token=None):
     login), which also (re)bootstraps the stored refresh token. Failures are
     logged and leave the existing token in place — they must not break
     authentication."""
-    now = datetime.utcnow()
+    now = utcnow()
     if member.urs_token and member.urs_token_expiration is not None \
             and now < member.urs_token_expiration - EDL_TOKEN_REFRESH_BUFFER:
         return
@@ -392,7 +397,7 @@ def _refresh_edl_token_direct(member):
 
     expiration = None
     if token.get("expires_in") is not None:
-        expiration = datetime.utcnow() + timedelta(seconds=int(token["expires_in"]))
+        expiration = utcnow() + timedelta(seconds=int(token["expires_in"]))
 
     return _persist_urs_tokens(member, token.get("access_token"),
                                token.get("refresh_token"), expiration)
@@ -408,9 +413,10 @@ def _refresh_edl_token_from_broker(member, kc_access_token):
     # Prefer the absolute expiration epoch; fall back to expires_in if absent.
     expiration = None
     if broker_token.get("accessTokenExpiration") is not None:
-        expiration = datetime.utcfromtimestamp(broker_token["accessTokenExpiration"])
+        expiration = datetime.fromtimestamp(broker_token["accessTokenExpiration"],
+                                            tz=timezone.utc).replace(tzinfo=None)
     elif broker_token.get("expires_in") is not None:
-        expiration = datetime.utcnow() + timedelta(seconds=int(broker_token["expires_in"]))
+        expiration = utcnow() + timedelta(seconds=int(broker_token["expires_in"]))
 
     return _persist_urs_tokens(member, broker_token.get("access_token"),
                                broker_token.get("refresh_token"), expiration)

--- a/api/auth/cas_auth.py
+++ b/api/auth/cas_auth.py
@@ -1,4 +1,4 @@
-from datetime import timedelta, datetime, timezone
+from datetime import timedelta, datetime
 
 import flask
 import requests
@@ -42,9 +42,6 @@ EDL_BROKER_ALIAS = "edl"
 
 # Refresh the stored EDL (URS) access token this long before it expires.
 EDL_TOKEN_REFRESH_BUFFER = timedelta(minutes=5)
-# Per-process cache of EDL access-token expirations, keyed by member id, used to
-# avoid calling the Keycloak broker endpoint on every authenticated request.
-_edl_token_expiration_cache = {}
 
 def validate(service, ticket):
     """
@@ -343,38 +340,98 @@ def start_member_session_jwt(decoded_jwt, token_string, auto_create_member=False
     return member
 
 
-def refresh_urs_token(member, kc_access_token):
-    """Refresh member.urs_token from the Keycloak EDL broker endpoint when it is
-    missing or close to expiring. Expirations are cached per-process by member id,
-    so the broker is not called on every authenticated request. Failures are logged
-    and leave the existing token in place — they must not break authentication."""
-    now = datetime.now(timezone.utc)
-    cached_expiration = _edl_token_expiration_cache.get(member.id)
-    if member.urs_token and cached_expiration is not None \
-            and now < cached_expiration - EDL_TOKEN_REFRESH_BUFFER:
+def refresh_urs_token(member, kc_access_token=None):
+    """Ensure member.urs_token holds a valid EDL (URS) access token, refreshing
+    it when missing or close to expiring. Refreshes directly against the EDL
+    token endpoint using the stored refresh token; falls back to the Keycloak
+    EDL broker endpoint when a live Keycloak access token is available (i.e. at
+    login), which also (re)bootstraps the stored refresh token. Failures are
+    logged and leave the existing token in place — they must not break
+    authentication."""
+    now = datetime.utcnow()
+    if member.urs_token and member.urs_token_expiration is not None \
+            and now < member.urs_token_expiration - EDL_TOKEN_REFRESH_BUFFER:
         return
 
+    if member.urs_refresh_token and _refresh_edl_token_direct(member):
+        return
+
+    if kc_access_token:
+        _refresh_edl_token_from_broker(member, kc_access_token)
+
+
+def get_urs_token(member_id):
+    """Return a valid EDL (URS) access token for the member, refreshing the
+    stored token first when it is missing or close to expiring. Returns None
+    if the member does not exist."""
+    member = db.session.query(Member).filter_by(id=member_id).first()
+    if member is None:
+        return None
+    refresh_urs_token(member)
+    return member.urs_token
+
+
+def _refresh_edl_token_direct(member):
+    """Refresh the member's EDL token set directly against the EDL token
+    endpoint using the stored refresh token. Returns True on success."""
+    try:
+        resp = requests.post(
+            settings.EDL_TOKEN_URL,
+            data={'grant_type': 'refresh_token', 'refresh_token': member.urs_refresh_token},
+            headers={'Authorization': f'Basic {settings.MAAP_EDL_CREDS}'},
+            timeout=settings.REQUESTS_TIMEOUT_SECONDS,
+        )
+        if resp.status_code != 200:
+            current_app.logger.warning(
+                f"EDL token refresh returned {resp.status_code} for {member.username}: {resp.text[:200]}")
+            return False
+        token = resp.json()
+    except Exception as e:
+        current_app.logger.warning(f"EDL token refresh failed for {member.username}: {e}")
+        return False
+
+    expiration = None
+    if token.get("expires_in") is not None:
+        expiration = datetime.utcnow() + timedelta(seconds=int(token["expires_in"]))
+
+    return _persist_urs_tokens(member, token.get("access_token"),
+                               token.get("refresh_token"), expiration)
+
+
+def _refresh_edl_token_from_broker(member, kc_access_token):
+    """Refresh the member's EDL token set from the Keycloak EDL broker
+    endpoint. Returns True on success."""
     broker_token = fetch_edl_broker_token(kc_access_token)
     if not broker_token:
-        return
-
-    new_token = broker_token.get("access_token")
-    if not new_token:
-        return
+        return False
 
     # Prefer the absolute expiration epoch; fall back to expires_in if absent.
+    expiration = None
     if broker_token.get("accessTokenExpiration") is not None:
-        _edl_token_expiration_cache[member.id] = datetime.fromtimestamp(broker_token["accessTokenExpiration"], timezone.utc)
+        expiration = datetime.utcfromtimestamp(broker_token["accessTokenExpiration"])
     elif broker_token.get("expires_in") is not None:
-        _edl_token_expiration_cache[member.id] = now + timedelta(seconds=int(broker_token["expires_in"]))
+        expiration = datetime.utcnow() + timedelta(seconds=int(broker_token["expires_in"]))
 
-    if new_token != member.urs_token:
-        member.urs_token = new_token
-        try:
-            db.session.commit()
-        except Exception:
-            db.session.rollback()
-            current_app.logger.exception(f"Failed to persist refreshed URS token for {member.username}")
+    return _persist_urs_tokens(member, broker_token.get("access_token"),
+                               broker_token.get("refresh_token"), expiration)
+
+
+def _persist_urs_tokens(member, access_token, refresh_token, expiration):
+    """Persist a refreshed EDL token set on the member. Returns True on success."""
+    if not access_token:
+        return False
+
+    member.urs_token = access_token
+    member.urs_token_expiration = expiration
+    if refresh_token:
+        member.urs_refresh_token = refresh_token
+    try:
+        db.session.commit()
+        return True
+    except Exception:
+        db.session.rollback()
+        current_app.logger.exception(f"Failed to persist refreshed URS token for {member.username}")
+        return False
 
 
 def fetch_edl_broker_token(kc_access_token):
@@ -390,7 +447,12 @@ def fetch_edl_broker_token(kc_access_token):
             headers={'Authorization': f'Bearer {kc_access_token}'},
             timeout=settings.REQUESTS_TIMEOUT_SECONDS,
         )
-        resp.raise_for_status()
+        # 401: token invalid or an id token was passed instead of an access token.
+        # 403: user lacks the broker client's read-token role.
+        if resp.status_code != 200:
+            current_app.logger.warning(
+                f"Keycloak broker EDL token request returned {resp.status_code}: {resp.text[:200]}")
+            return None
         return resp.json()
     except Exception as e:
         current_app.logger.warning(f"Failed to retrieve EDL token from Keycloak broker: {e}")

--- a/api/auth/security.py
+++ b/api/auth/security.py
@@ -6,7 +6,7 @@ from flask_api import status
 from werkzeug.exceptions import HTTPException
 from api import settings, constants
 from api.utils.security_utils import AuthenticationError, ExternalServiceError
-from api.auth.cas_auth import start_member_session_jwt, validate_proxy, validate_third_party
+from api.auth.cas_auth import start_member_session_jwt, validate_proxy, validate_third_party, get_urs_token
 from api.maap_database import db
 from api.models.member import Member
 from api.models.personal_access_token import PersonalAccessToken
@@ -254,7 +254,7 @@ def edl_federated_request(url, stream_response=False):
         maap_user = get_authorized_user()
 
         if maap_user is not None:
-            urs_token = db.session.query(Member).filter_by(id=maap_user.id).first().urs_token
+            urs_token = get_urs_token(maap_user.id)
             s.headers.update({'Authorization': f'Bearer {urs_token},Basic {settings.MAAP_EDL_CREDS}',
                               'Connection': 'close'})
 

--- a/api/endpoints/cmr.py
+++ b/api/endpoints/cmr.py
@@ -11,6 +11,7 @@ from flask_api import status
 from werkzeug.exceptions import BadRequest, RequestEntityTooLarge, ServiceUnavailable
 from api.restplus import api
 from api.auth.security import get_authorized_user, edl_federated_request
+from api.auth.cas_auth import get_urs_token
 from api.maap_database import db
 from api.models.member import Member
 from urllib import parse
@@ -223,7 +224,7 @@ class CmrGranuleData(Resource):
             if maap_user is None:
                 return Response(response.text, status=401)
             else:
-                urs_token = db.session.query(Member).filter_by(id=maap_user.id).first().urs_token
+                urs_token = get_urs_token(maap_user.id)
                 s.headers.update({'Authorization': f'Bearer {urs_token},Basic {settings.MAAP_EDL_CREDS}',
                                   'Connection': 'close'})
 

--- a/api/endpoints/members.py
+++ b/api/endpoints/members.py
@@ -11,6 +11,7 @@ from api.restplus import api
 import api.settings as settings
 from api import constants
 from api.auth.security import get_authorized_user, login_required, valid_dps_request, edl_federated_request
+from api.auth.cas_auth import get_urs_token
 from api.maap_database import db
 from api.utils import github_util
 from api.models.member import Member as Member_db
@@ -855,7 +856,7 @@ def get_edc_credentials(endpoint_uri, user_id):
     credentials are valid to avoid unnecessary generation of new credentials and
     to minimize load on the endpoint, while also ensuring reasonable "freshness".
     """
-    urs_token = db.session.query(Member_db).filter_by(id=user_id).first().urs_token
+    urs_token = get_urs_token(user_id)
 
     s = requests.Session()
 

--- a/api/models/member.py
+++ b/api/models/member.py
@@ -16,6 +16,8 @@ class Member(Base):
     public_ssh_key_name = db.Column(db.String())
     public_ssh_key_modified_date = db.Column(db.DateTime())
     urs_token = db.Column(db.String())
+    urs_refresh_token = db.Column(db.String())
+    urs_token_expiration = db.Column(db.DateTime())
     status = db.Column(db.String())
     gitlab_id = db.Column(db.String())
     gitlab_username = db.Column(db.String())

--- a/api/settings.py
+++ b/api/settings.py
@@ -34,6 +34,8 @@ UMM_G_VERSION = os.getenv('UMM_G_VERSION', '1.6')
 MAAP_WMTS_XML = os.getenv('MAAP_WMTS_XML', '/maap-api-nasa/api/maap.wmts.xml')
 MAAP_EDL_CREDS = os.getenv('MAAP_EDL_CREDS','')
 MAAP_TEMP_URS_TOKEN = os.getenv('MAAP_TEMP_URS_TOKEN','')
+# EarthData Login OAuth token endpoint, used to refresh stored user EDL tokens directly. 
+EDL_TOKEN_URL = os.getenv('EDL_TOKEN_URL', 'https://urs.earthdata.nasa.gov/oauth/token')
 
 # GIT settings
 GIT_REPO_URL = os.getenv('GIT_REPO_URL','https://gitlab-ci-token:$TOKEN@repo.dit.maap-project.org/root/register-job.git')

--- a/sql/member_urs_refresh_token.sql
+++ b/sql/member_urs_refresh_token.sql
@@ -1,0 +1,5 @@
+-- Adds EDL refresh-token support to the member table.
+-- Required because db.create_all() does not alter existing tables.
+-- Run against each venue's database before deploying the API changes.
+ALTER TABLE member ADD COLUMN IF NOT EXISTS urs_refresh_token VARCHAR;
+ALTER TABLE member ADD COLUMN IF NOT EXISTS urs_token_expiration TIMESTAMP;

--- a/test/api/auth/test_cas_auth.py
+++ b/test/api/auth/test_cas_auth.py
@@ -10,6 +10,7 @@ from api.models.member_session import MemberSession
 from api.models.role import Role
 from api.auth.cas_auth import validate, validate_proxy, validate_bearer, decrypt_proxy_ticket
 from api.auth.cas_auth import start_member_session, get_cas_attribute_value
+from api.auth.cas_auth import refresh_urs_token, get_urs_token
 from api.utils.security_utils import AuthenticationError
 from api import settings
 
@@ -545,6 +546,240 @@ class TestCASAuthentication(unittest.TestCase):
             assert regular_member.email == "regular@example.com"
             assert regular_member.organization == "NASA"
             assert regular_member.urs_token == "regular-user-token-123"  # Should use their own token
+
+
+EDL_TOKEN_URL_TEST = 'https://edl.test/oauth/token'
+KC_BROKER_URL_TEST = 'https://kc.test/realms/maap/broker/edl/token'
+
+
+@patch('api.settings.EDL_TOKEN_URL', EDL_TOKEN_URL_TEST)
+@patch('api.settings.KEYCLOAK_SERVER_URL', 'https://kc.test/')
+@patch('api.settings.KEYCLOAK_REALM', 'maap')
+class TestUrsTokenRefresh(unittest.TestCase):
+
+    def setUp(self):
+        """Set up test environment before each test."""
+        with app.app_context():
+            initialize_sql(db.engine)
+            db.session.query(MemberSession).delete()
+            db.session.query(Member).delete()
+            db.session.query(Role).delete()
+            db.session.commit()
+
+            guest_role = Role(id=Role.ROLE_GUEST, role_name='guest')
+            db.session.add(guest_role)
+            db.session.commit()
+
+    def tearDown(self):
+        """Clean up after each test."""
+        with app.app_context():
+            db.session.query(MemberSession).delete()
+            db.session.query(Member).delete()
+            db.session.query(Role).delete()
+            db.session.commit()
+
+    def _create_member(self, urs_token=None, urs_refresh_token=None, urs_token_expiration=None):
+        member = Member(
+            username='tokenuser',
+            first_name='Token',
+            last_name='User',
+            email='tokenuser@example.com',
+            organization='NASA',
+            role_id=Role.ROLE_GUEST,
+            urs_token=urs_token,
+            urs_refresh_token=urs_refresh_token,
+            urs_token_expiration=urs_token_expiration
+        )
+        db.session.add(member)
+        db.session.commit()
+        return member
+
+    @responses.activate
+    def test_refresh_skipped_when_token_still_valid(self):
+        """Test: no refresh attempt is made while the stored token is fresh"""
+        with app.app_context():
+            # Given a member whose EDL token expires well in the future
+            member = self._create_member(
+                urs_token='valid-edl-token',
+                urs_refresh_token='edl-refresh-token',
+                urs_token_expiration=datetime.utcnow() + timedelta(hours=12)
+            )
+
+            # When refresh is requested (no HTTP endpoints are registered, so
+            # any outbound call would raise a ConnectionError via responses)
+            refresh_urs_token(member)
+
+            # Then the token is untouched and no HTTP calls were made
+            assert member.urs_token == 'valid-edl-token'
+            assert len(responses.calls) == 0
+
+    @responses.activate
+    def test_direct_refresh_when_token_expired(self):
+        """Test: an expired token is refreshed directly against EDL"""
+        with app.app_context():
+            # Given a member with an expired EDL token and a stored refresh token
+            member = self._create_member(
+                urs_token='expired-edl-token',
+                urs_refresh_token='edl-refresh-token',
+                urs_token_expiration=datetime.utcnow() - timedelta(hours=1)
+            )
+            responses.add(
+                responses.POST,
+                EDL_TOKEN_URL_TEST,
+                json={'access_token': 'fresh-edl-token',
+                      'refresh_token': 'rotated-refresh-token',
+                      'expires_in': 86400},
+                status=200
+            )
+
+            # When refresh is requested
+            refresh_urs_token(member)
+
+            # Then the token set is refreshed and persisted
+            assert member.urs_token == 'fresh-edl-token'
+            assert member.urs_refresh_token == 'rotated-refresh-token'
+            expected_exp = datetime.utcnow() + timedelta(seconds=86400)
+            assert abs((member.urs_token_expiration - expected_exp).total_seconds()) < 60
+
+            # And the refresh grant was sent to EDL
+            assert 'grant_type=refresh_token' in responses.calls[0].request.body
+            assert 'refresh_token=edl-refresh-token' in responses.calls[0].request.body
+
+    @responses.activate
+    def test_direct_refresh_keeps_old_refresh_token_when_not_rotated(self):
+        """Test: the stored refresh token is kept if EDL does not return a new one"""
+        with app.app_context():
+            member = self._create_member(
+                urs_token='expired-edl-token',
+                urs_refresh_token='edl-refresh-token',
+                urs_token_expiration=datetime.utcnow() - timedelta(hours=1)
+            )
+            responses.add(
+                responses.POST,
+                EDL_TOKEN_URL_TEST,
+                json={'access_token': 'fresh-edl-token', 'expires_in': 86400},
+                status=200
+            )
+
+            refresh_urs_token(member)
+
+            assert member.urs_token == 'fresh-edl-token'
+            assert member.urs_refresh_token == 'edl-refresh-token'
+
+    @responses.activate
+    def test_direct_refresh_failure_falls_back_to_broker(self):
+        """Test: broker endpoint is used when the direct EDL refresh fails"""
+        with app.app_context():
+            # Given a member with an invalid refresh token and a live Keycloak access token
+            member = self._create_member(
+                urs_token='expired-edl-token',
+                urs_refresh_token='revoked-refresh-token',
+                urs_token_expiration=datetime.utcnow() - timedelta(hours=1)
+            )
+            responses.add(responses.POST, EDL_TOKEN_URL_TEST, status=401)
+            responses.add(
+                responses.GET,
+                KC_BROKER_URL_TEST,
+                json={'access_token': 'broker-edl-token',
+                      'refresh_token': 'broker-refresh-token',
+                      'expires_in': 86400,
+                      'accessTokenExpiration': int((datetime.utcnow() + timedelta(days=1)
+                                                    - datetime(1970, 1, 1)).total_seconds())},
+                status=200
+            )
+
+            # When refresh is requested with a Keycloak access token
+            refresh_urs_token(member, 'jwt:kc-access-token')
+
+            # Then the token set comes from the broker
+            assert member.urs_token == 'broker-edl-token'
+            assert member.urs_refresh_token == 'broker-refresh-token'
+
+            # And the jwt: prefix was stripped before calling the broker
+            broker_call = responses.calls[1].request
+            assert broker_call.headers['Authorization'] == 'Bearer kc-access-token'
+
+    @responses.activate
+    def test_broker_bootstraps_refresh_token_at_login(self):
+        """Test: at login, the broker populates the refresh token for members without one"""
+        with app.app_context():
+            # Given a member who has never stored a refresh token (pre-migration row)
+            member = self._create_member(urs_token='old-edl-token')
+            responses.add(
+                responses.GET,
+                KC_BROKER_URL_TEST,
+                json={'access_token': 'broker-edl-token',
+                      'refresh_token': 'bootstrapped-refresh-token',
+                      'expires_in': 86400},
+                status=200
+            )
+
+            # When refresh is requested at login (live Keycloak token, no stored refresh token)
+            refresh_urs_token(member, 'kc-access-token')
+
+            # Then the full token set is bootstrapped from the broker
+            assert member.urs_token == 'broker-edl-token'
+            assert member.urs_refresh_token == 'bootstrapped-refresh-token'
+            assert member.urs_token_expiration is not None
+            # And the direct EDL endpoint was never attempted
+            assert len(responses.calls) == 1
+
+    @responses.activate
+    def test_refresh_failure_keeps_existing_token(self):
+        """Test: refresh failures leave the stored token in place"""
+        with app.app_context():
+            # Given a member with an expired token and no live Keycloak token
+            member = self._create_member(
+                urs_token='expired-edl-token',
+                urs_refresh_token='revoked-refresh-token',
+                urs_token_expiration=datetime.utcnow() - timedelta(hours=1)
+            )
+            responses.add(responses.POST, EDL_TOKEN_URL_TEST, status=401)
+
+            # When refresh fails on all paths
+            refresh_urs_token(member)
+
+            # Then the existing (stale) token remains rather than being cleared
+            assert member.urs_token == 'expired-edl-token'
+
+    @responses.activate
+    def test_legacy_member_without_expiration_is_left_alone(self):
+        """Test: legacy rows (token but no expiration/refresh token) do not break"""
+        with app.app_context():
+            # Given a pre-migration member: token present, no expiration, no refresh token
+            member = self._create_member(urs_token='legacy-edl-token')
+
+            # When refresh is requested without a Keycloak token (e.g. workspace request)
+            refresh_urs_token(member)
+
+            # Then nothing is attempted and the token is unchanged
+            assert member.urs_token == 'legacy-edl-token'
+            assert len(responses.calls) == 0
+
+    @responses.activate
+    def test_get_urs_token_refreshes_and_returns_token(self):
+        """Test: get_urs_token refreshes a stale token and returns the fresh one"""
+        with app.app_context():
+            member = self._create_member(
+                urs_token='expired-edl-token',
+                urs_refresh_token='edl-refresh-token',
+                urs_token_expiration=datetime.utcnow() - timedelta(hours=1)
+            )
+            responses.add(
+                responses.POST,
+                EDL_TOKEN_URL_TEST,
+                json={'access_token': 'fresh-edl-token', 'expires_in': 86400},
+                status=200
+            )
+
+            result = get_urs_token(member.id)
+
+            assert result == 'fresh-edl-token'
+
+    def test_get_urs_token_returns_none_for_missing_member(self):
+        """Test: get_urs_token returns None for a nonexistent member id"""
+        with app.app_context():
+            assert get_urs_token(999999) is None
 
 
 if __name__ == '__main__':

--- a/test/api/auth/test_cas_auth.py
+++ b/test/api/auth/test_cas_auth.py
@@ -10,7 +10,7 @@ from api.models.member_session import MemberSession
 from api.models.role import Role
 from api.auth.cas_auth import validate, validate_proxy, validate_bearer, decrypt_proxy_ticket
 from api.auth.cas_auth import start_member_session, get_cas_attribute_value
-from api.auth.cas_auth import refresh_urs_token, get_urs_token
+from api.auth.cas_auth import refresh_urs_token, get_urs_token, utcnow
 from api.utils.security_utils import AuthenticationError
 from api import settings
 
@@ -87,7 +87,7 @@ class TestCASAuthentication(unittest.TestCase):
             mock_session = MemberSession(
                 member_id=mock_member.id,
                 session_key='PGT-12345-test',
-                creation_date=datetime.utcnow()
+                creation_date=utcnow()
             )
             mock_validate_proxy.return_value = mock_session
             
@@ -146,7 +146,7 @@ class TestCASAuthentication(unittest.TestCase):
             session = MemberSession(
                 member_id=member.id,
                 session_key='PGT-12345-test',
-                creation_date=datetime.utcnow()
+                creation_date=utcnow()
             )
             db.session.add(session)
             db.session.commit()
@@ -177,7 +177,7 @@ class TestCASAuthentication(unittest.TestCase):
             db.session.commit()
             
             # Create an expired session (older than 60 days)
-            expired_date = datetime.utcnow() - timedelta(days=61)
+            expired_date = utcnow() - timedelta(days=61)
             session = MemberSession(
                 member_id=member.id,
                 session_key='PGT-expired-test',
@@ -602,7 +602,7 @@ class TestUrsTokenRefresh(unittest.TestCase):
             member = self._create_member(
                 urs_token='valid-edl-token',
                 urs_refresh_token='edl-refresh-token',
-                urs_token_expiration=datetime.utcnow() + timedelta(hours=12)
+                urs_token_expiration=utcnow() + timedelta(hours=12)
             )
 
             # When refresh is requested (no HTTP endpoints are registered, so
@@ -621,7 +621,7 @@ class TestUrsTokenRefresh(unittest.TestCase):
             member = self._create_member(
                 urs_token='expired-edl-token',
                 urs_refresh_token='edl-refresh-token',
-                urs_token_expiration=datetime.utcnow() - timedelta(hours=1)
+                urs_token_expiration=utcnow() - timedelta(hours=1)
             )
             responses.add(
                 responses.POST,
@@ -638,7 +638,7 @@ class TestUrsTokenRefresh(unittest.TestCase):
             # Then the token set is refreshed and persisted
             assert member.urs_token == 'fresh-edl-token'
             assert member.urs_refresh_token == 'rotated-refresh-token'
-            expected_exp = datetime.utcnow() + timedelta(seconds=86400)
+            expected_exp = utcnow() + timedelta(seconds=86400)
             assert abs((member.urs_token_expiration - expected_exp).total_seconds()) < 60
 
             # And the refresh grant was sent to EDL
@@ -652,7 +652,7 @@ class TestUrsTokenRefresh(unittest.TestCase):
             member = self._create_member(
                 urs_token='expired-edl-token',
                 urs_refresh_token='edl-refresh-token',
-                urs_token_expiration=datetime.utcnow() - timedelta(hours=1)
+                urs_token_expiration=utcnow() - timedelta(hours=1)
             )
             responses.add(
                 responses.POST,
@@ -674,7 +674,7 @@ class TestUrsTokenRefresh(unittest.TestCase):
             member = self._create_member(
                 urs_token='expired-edl-token',
                 urs_refresh_token='revoked-refresh-token',
-                urs_token_expiration=datetime.utcnow() - timedelta(hours=1)
+                urs_token_expiration=utcnow() - timedelta(hours=1)
             )
             responses.add(responses.POST, EDL_TOKEN_URL_TEST, status=401)
             responses.add(
@@ -683,7 +683,7 @@ class TestUrsTokenRefresh(unittest.TestCase):
                 json={'access_token': 'broker-edl-token',
                       'refresh_token': 'broker-refresh-token',
                       'expires_in': 86400,
-                      'accessTokenExpiration': int((datetime.utcnow() + timedelta(days=1)
+                      'accessTokenExpiration': int((utcnow() + timedelta(days=1)
                                                     - datetime(1970, 1, 1)).total_seconds())},
                 status=200
             )
@@ -732,7 +732,7 @@ class TestUrsTokenRefresh(unittest.TestCase):
             member = self._create_member(
                 urs_token='expired-edl-token',
                 urs_refresh_token='revoked-refresh-token',
-                urs_token_expiration=datetime.utcnow() - timedelta(hours=1)
+                urs_token_expiration=utcnow() - timedelta(hours=1)
             )
             responses.add(responses.POST, EDL_TOKEN_URL_TEST, status=401)
 
@@ -763,7 +763,7 @@ class TestUrsTokenRefresh(unittest.TestCase):
             member = self._create_member(
                 urs_token='expired-edl-token',
                 urs_refresh_token='edl-refresh-token',
-                urs_token_expiration=datetime.utcnow() - timedelta(hours=1)
+                urs_token_expiration=utcnow() - timedelta(hours=1)
             )
             responses.add(
                 responses.POST,


### PR DESCRIPTION
- Added support for EDL refresh tokens in the member model.
- Introduced `get_urs_token` function to manage token retrieval and refresh logic.
- Updated member and cmr endpoints to utilize the new token management functions.
- Created SQL script to alter the member table for new token fields.

Community issue: https://github.com/MAAP-Project/Community/issues/1301
Related PR: https://github.com/2i2c-org/infrastructure/pull/8741