### PR TITLE
More efficient job status function and job inputs returned with getJobDetails

### DIFF
--- a/api/endpoints/ogc.py
+++ b/api/endpoints/ogc.py
@@ -795,6 +795,19 @@ class Status(Resource):
                 "description": existing_process.description,
                 "keywords": existing_process.keywords.split(",") if existing_process.keywords is not None else [], 
             }
+
+        # Bare minimum response body to pass back
+        response_body = {
+                    "jobID": job_id,
+                    "processID": existing_process.process_id if existing_process else "Error getting process ID",
+                    # TODO graceal should this be hard coded in if the example options are process, wps, openeo?
+                    "type": None,
+                    "status": current_status
+                }
+        get_job_details = request.args.get("getJobDetails", False)
+        if not request.args.get("fields") and not get_job_details:
+            return response_body, status.HTTP_200_OK 
+
         submitted_time = time_start = time_end = None
         try:
             current_status = ogc.hysds_to_ogc_status(current_status)
@@ -823,14 +836,6 @@ class Status(Resource):
             print(ex)
             print(f"ERROR getting products for job {job_id}")
 
-        # Bare minimum response body to pass back
-        response_body = {
-            "jobID": job_id,
-            "processID": existing_process.process_id if existing_process else "Error getting process ID",
-            # TODO graceal should this be hard coded in if the example options are process, wps, openeo?
-            "type": None,
-            "status": current_status
-        }
         # job_info represents all additional fields a user can request about the job
         job_info.update(response_body)
         fields_to_specify = request.args.get("fields").split(',') if request.args.get("fields") else []
@@ -840,6 +845,16 @@ class Status(Resource):
         except Exception as ex:
             print(ex)
             process_name = "Error getting process name"
+
+        try:
+            if current_status == ogc.DEDUPED_OGC_STATUS:
+                inputs = response["job"]["job_info"]["payload"]["job_specification"]["params"]
+            else:
+                inputs = response["job"]["params"]["job_specification"]["params"]
+        except Exception as ex:
+            print("Error finding job inputs")
+            print(ex)
+            inputs = None
 
         job_info.update({
             "request": None,
@@ -861,9 +876,9 @@ class Status(Resource):
                     "hreflang": HREF_LANG,
                     "title": "Job Status"
                 }
-            ]
+            ],
+            "inputs": inputs
         })
-        get_job_details = request.args.get("getJobDetails", False)
         if get_job_details and get_job_details.lower() == "true":
             # don't just return job_info because user can also request inputs through the fields parameter
             response_body.update(job_info)
@@ -871,16 +886,6 @@ class Status(Resource):
         for field in fields_to_specify:
             if field in job_info:
                 response_body[field] = job_info[field]
-            elif field == "inputs":
-                try:
-                    if current_status == ogc.DEDUPED_OGC_STATUS:
-                        response_body[field] = response["job"]["job_info"]["payload"]["job_specification"]["params"]
-                    else:
-                        response_body[field] = response["job"]["params"]["job_specification"]["params"]
-                except Exception as ex:
-                    print("Error finding job inputs")
-                    print(ex)
-                    response_body[field] = None
             elif field not in ["jobID", "type", "status", "processID"]:
                 return generate_error(f"Invalid field requested {field}. Remember to separate fields with commas", status.HTTP_400_BAD_REQUEST)
         return response_body, status.HTTP_200_OK 

--- a/api/endpoints/ogc.py
+++ b/api/endpoints/ogc.py
@@ -796,6 +796,8 @@ class Status(Resource):
                 "keywords": existing_process.keywords.split(",") if existing_process.keywords is not None else [], 
             }
 
+        current_status = ogc.hysds_to_ogc_status(current_status)
+
         # Bare minimum response body to pass back
         response_body = {
                     "jobID": job_id,
@@ -804,13 +806,13 @@ class Status(Resource):
                     "type": None,
                     "status": current_status
                 }
+        # Short circuit parsing if user doesnt want anymore information
         get_job_details = request.args.get("getJobDetails", False)
         if not request.args.get("fields") and not get_job_details:
             return response_body, status.HTTP_200_OK 
 
         submitted_time = time_start = time_end = None
         try:
-            current_status = ogc.hysds_to_ogc_status(current_status)
             submitted_time = response["job"]["job_info"]["time_queued"]
             time_start = response["job"]["job_info"]["time_start"]
             time_end = response["job"]["job_info"]["time_end"]


### PR DESCRIPTION
- job status function doesn't do all parsing if user doesn't send any parameters 
- getJobDetails true now returns inputs 
      - I think this is a good feature but also specifically for the MAAP MMGIS plugin, I think getJobDetails parameter is a good thing to try to contribute back for OGC because OGC standards don't have any standard for getting the inputs back for parameters passed into the job with the status call. The getJobDetails parameter is a good way to return all relevant information about the job like inputs, created time, etc. 

This is deployed on UAT right now if you would like to test